### PR TITLE
Fix #71: add code_of function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ Improvements:
 - ``Scanner`` parameters can now be set in the constructor.
 - Parameters can now be locked independently of the parent device. However, if
   done so, no one else can lock the device.
+- Add ``code_of`` function to show the source of a function.
 
 API breaks:
 

--- a/concert/session.py
+++ b/concert/session.py
@@ -106,6 +106,20 @@ def pdoc(hide_blacklisted=True):
     print(table.get_string())
 
 
+def code_of(func):
+    """Show implementation of *func*."""
+    source = inspect.getsource(func)
+
+    try:
+        from pygments import highlight
+        from pygments.lexers import PythonLexer
+        from pygments.formatters import TerminalFormatter
+
+        print(highlight(source, PythonLexer(), TerminalFormatter()))
+    except ImportError:
+        print(source)
+
+
 def path(session):
     """Get absolute path of *session* module."""
     return os.path.join(PATH, session + '.py')

--- a/docs/usage/sessions.rst
+++ b/docs/usage/sessions.rst
@@ -220,6 +220,17 @@ functions and processes and may look like this::
                            are installed.
     ------------------------------------------------------------------------------
 
+In case you are interested in the implementation of a function, you can use
+:func:`.code_of`. For example::
+
+    In [5]: code_of(pdoc)
+    def pdoc(hide_blacklisted=True):
+        """Render process documentation."""
+        black_listed = ('show', 'start', 'init', 'rm', 'log', 'edit', 'fetch')
+        field_names = ["Name", "Description"]
+        table = get_default_table(field_names)
+        ...
+
 
 .. _pint: https://pint.readthedocs.org/en/latest/
 


### PR DESCRIPTION
In case Pygments is installed, the code is colorized first. Corresponds to issue #71.
