### PR TITLE
Import external soft deps even if load fails

### DIFF
--- a/concert/ext/nexus.py
+++ b/concert/ext/nexus.py
@@ -7,10 +7,14 @@ sets. It uses NeXpy_ to interface with NeXus.
 .. _NeXpy: http://wiki.nexusformat.org/NeXpy
 """
 import numpy as np
-from nexpy.api import nexus as nx
 from concert.base import Parameter
 from concert.devices import cameras, monochromators
 from concert.helpers import async
+
+try:
+    from nexpy.api import nexus as nx
+except ImportError:
+    print("NeXpy or libnexus are not installed")
 
 
 def get_detector(_camera):

--- a/concert/ext/qt.py
+++ b/concert/ext/qt.py
@@ -1,5 +1,8 @@
 """Qt Widget."""
-from PyQt4 import QtGui
+try:
+    from PyQt4 import QtGui
+except ImportError:
+    print("PyQt4 is not installed")
 
 
 def make(device):

--- a/concert/ext/ufo.py
+++ b/concert/ext/ufo.py
@@ -17,10 +17,14 @@ the UFO data processing framework. The simplest example could look like this::
     proc.push(scipy.misc.lena())
     proc.wait()
 """
-from gi.repository import Ufo
 import threading
-import ufonp
 import numpy as np
+
+try:
+    from gi.repository import Ufo
+    import ufonp
+except ImportError:
+    print("Ufo typelibs or ufonp are not installed")
 
 
 class PluginManager(object):


### PR DESCRIPTION
This way we can still extract docstrings from exported functions and classes.

@sensej: This change will also address part of #88.
