### PR TITLE
Recreate numpy array on every uca camera grab

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -38,7 +38,7 @@ def _create_data_array(camera):
     bits = camera.props.sensor_bitdepth
     dtype = np.uint16 if bits > 8 else np.uint8
     dims = camera.props.roi_height, camera.props.roi_width
-    array = np.zeros(dims, dtype=dtype)
+    array = np.empty(dims, dtype=dtype)
     return (array, array.__array_interface__['data'][0])
 
 


### PR DESCRIPTION
In case more images is grabbed they cannot be overwritten, thus the numpy array is created on every `grab` call.
