### PR TITLE
Fix #106: add pco specific camera type

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -4,6 +4,7 @@ Cameras supported by the libuca library.
 import numpy as np
 from concert.quantities import q
 from concert.base import Parameter
+from concert.helpers import Bunch
 from concert.devices.cameras import base
 
 
@@ -112,3 +113,28 @@ class Camera(base.Camera):
             return array
 
         return None
+
+
+class Pco(Camera):
+
+    def __init__(self):
+        super(Pco, self).__init__('pco')
+
+        class _Dummy(object):
+            pass
+
+        setattr(self.uca, 'enum_values', _Dummy())
+
+        def get_enum_bunch(enum):
+            enum_map = {}
+
+            for key, value in enum.__enum_values__.items():
+                name = value.value_nick.upper().replace('-', '_')
+                enum_map[name] = key
+
+            return Bunch(enum_map)
+
+        for prop in self.uca.props:
+            if hasattr(prop, 'enum_class'):
+                setattr(self.uca.enum_values, prop.name.replace('-', '_'),
+                        get_enum_bunch(prop.default_value))


### PR DESCRIPTION
This adds a pco camera device applicable to all pco cameras. It fixes #106 by patching the enums. However, there are two caveats:
1. Patching makes use of `__enum_values__` which is a real deep internal detail.
2. This change has not been tested yet.

This change should be added before #105 on which the `Dimax` type can be built on.
