### PR TITLE
Refactor image averaging

### DIFF
--- a/concert/coroutines.py
+++ b/concert/coroutines.py
@@ -90,7 +90,10 @@ class ImageAverager(object):
     @coroutine
     def average_images(self):
         """Average images as they come."""
+        # Reset the average for every coroutine start
+        self.average = None
         i = 0
+
         while True:
             data = yield
             if self.average is None:


### PR DESCRIPTION
I wanted to check with @matze first because it is quite different from before. Now one can do:

``` python
averager = get_image_averager()
producer(averager())
do_stuff_with(averager.average)
```

It seems more pythonic, but strictly speaking the outer `get_image_averager` is not a coroutine anymore.
