### PR TITLE
 Log concert internals as debug instead of info

### DIFF
--- a/concert/base.py
+++ b/concert/base.py
@@ -230,7 +230,7 @@ class Parameter(object):
             """Log access."""
             msg = "{0}: {1} {2}='{3}'"
             name = self.owner.__class__.__name__
-            LOG.info(msg.format(name, what, self.name, value))
+            LOG.debug(msg.format(name, what, self.name, value))
 
         log_access('try')
 

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -56,5 +56,5 @@ def write_libtiff(file_name_prefix, data):
 def create_directory(directory, rights=0o0750):
     """Create *directory* and all paths along the way if necessary."""
     if not os.path.exists(directory):
-        LOG.info("Creating directory {}".format(directory))
+        LOG.debug("Creating directory {}".format(directory))
         os.makedirs(directory, rights)


### PR DESCRIPTION
It's tiny but I wanted to bring this up to check with @matze and also to decide what logging output goes where. I think all the concert internal logging should go to `DEBUG`, otherwise we will overwhelm users with logging information (I output everything that is in `INFO` level to the log file of an experiment because that seemed like a reasonable way to do it).
