### PR TITLE
Increase maximum allow line length

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,6 @@ envlist = py27, py32, py33
 sitepackages=True
 commands = {envpython} runtests.py
 deps = -r{toxinidir}/requirements.txt
+
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
I was getting annoyed, so although PEP8 generally advises to use 79 characters, there is an exception
given:

> Some teams strongly prefer a longer line length. For code maintained
> exclusively or primarily by a team that can reach agreement on this issue, it
> is okay to increase the nominal line length from 80 to 100 characters
> (effectively increasing the maximum length to 99 characters), provided that
> comments and docstrings are still wrapped at 72 characters.

Hereby, the limit is lifted to 99 characters and flake8 stopped from being
complaining. If you need longer lines, consider refactoring your code by writing
functions or store intermediate results in variables.
