### PR TITLE
Fix issue 179

### DIFF
--- a/concert/fsm.py
+++ b/concert/fsm.py
@@ -20,6 +20,7 @@ class Error(Exception):
 class StateValue(object):
 
     def __init__(self, default):
+        self._default = default
         self._current = default
         self._error = None
 
@@ -30,6 +31,17 @@ class StateValue(object):
     @property
     def error(self):
         return self._error
+
+    def reset(self):
+        """
+        Resets the current state value to the default value.
+
+        It is strongly recommended, that this function is called only by the
+        device author in a device-specific reset function. By calling this
+        manually, you risk of having states out-of-sync with the real device
+        state.
+        """
+        self._current = self._default
 
     def is_currently(self, state):
         return self._current == state

--- a/concert/tests/unit/test_fsm.py
+++ b/concert/tests/unit/test_fsm.py
@@ -41,6 +41,9 @@ class SomeDevice(Device):
     def cause_erroneous_behaviour(self, msg):
         raise Error(msg)
 
+    def reset(self):
+        self.state.reset()
+
 
 class TestStateMachine(TestCase):
 
@@ -87,3 +90,6 @@ class TestStateMachine(TestCase):
 
         self.assertTrue(self.device.state.is_currently('error'))
         self.assertEqual(self.device.state.error, "Oops")
+
+        self.device.reset()
+        self.assertTrue(self.device.state.is_currently('standby'))


### PR DESCRIPTION
This PR adds two major changes the way states are handled in order to fix #179:
- An explicit `fsm.Error` exception must be raised by the device author in order to put the state into an error mode.
- An error state can be recovered by calling `.reset()` on it, which will set the state back to the default one. However, it is probably not a good idea, to let the user be able to do it.
