### PR TITLE
Add recording() context manager

### DIFF
--- a/concert/devices/cameras/base.py
+++ b/concert/devices/cameras/base.py
@@ -47,6 +47,7 @@ To setup and use a camera in a typical environment, you would do::
 
     print("mean=%f, stddev=%f" % (np.mean(data), np.std(data))
 """
+import contextlib
 from concert.base import Parameter, Quantity, State, transition
 from concert.quantities import q
 from concert.helpers import Bunch
@@ -85,6 +86,20 @@ class Camera(Device):
     def stop_recording(self):
         """Stop recording frames."""
         self._stop_real()
+
+    @contextlib.contextmanager
+    def recording(self):
+        """
+        A context manager for starting and stopping the camera.
+
+        In general it is used with the ``with`` keyword like this::
+
+            with camera.recording():
+                frame = camera.grab()
+        """
+        self.start_recording()
+        yield
+        self.stop_recording()
 
     def trigger(self):
         """Trigger a frame if possible."""

--- a/concert/tests/unit/devices/test_camera.py
+++ b/concert/tests/unit/devices/test_camera.py
@@ -33,3 +33,12 @@ class TestDummyCamera(TestCase):
         for i, item in enumerate(camera.readout_buffer()):
             pass
         self.assertEqual(i, 2)
+
+    def test_context_manager(self):
+        camera = Camera()
+
+        with camera.recording():
+            self.assertEqual(camera.state, 'recording')
+            f = camera.grab()
+
+        self.assertEqual(camera.state, 'standby')


### PR DESCRIPTION
This is a simpler way to ensure that the camera is in recording mode during acquisition and stops recording afterwards. Because this adds to the API, I wanted to check with @sensej, if this is alright. Personally, it nagged me to always call start/stop recording.
