### PR TITLE
Add @quantity decorator

### DIFF
--- a/concert/base.py
+++ b/concert/base.py
@@ -5,6 +5,7 @@ import logging
 import six
 import collections
 import functools
+import inspect
 from concert.helpers import memoize
 from concert.async import async, wait
 
@@ -447,6 +448,32 @@ class Quantity(Parameter):
         converted = self.convert_to(instance, value)
         super(Quantity, self).__set__(instance, converted)
 
+
+def quantity(unit=None, lower=None, upper=None, conversion=identity,
+             data=None, transition=None, help=None):
+    """
+    Decorator for read-only quantity functions.
+
+    Device authors can add additional read-only quantities to a specific device
+    by applying this decorator to a function::
+
+        class SomeDevice(Device):
+            @quantity(unit=1*q.mm, lower=0*q.mm, upper=2*q.mm)
+            def position(self):
+                pass
+
+    The arguments correspond to those of :class:`.Quantity`.
+    """
+
+    def wrapper(func):
+        # Get help info from doc string if no explicit help was passed.
+        doc = help if help else inspect.getdoc(func)
+
+        return Quantity(fget=func, unit=unit, lower=lower, upper=upper,
+                        conversion=conversion, data=data,
+                        transition=transition, help=doc)
+
+    return wrapper
 
 class ParameterValue(object):
 


### PR DESCRIPTION
After adding [this](https://github.com/ufo-kit/concert/blob/8656a648a98c1cdc67cf87fb60e3649f66b379a8/concert/devices/cameras/uca.py#L246-L252) property to the `camera.Ufo` class, I noticed that I actually wanted to specify an additional quantity rather than just a stupid property.

This PR adds a `quantity`decorator that can be applied to a method that returns the corresponding value. Initially, I wanted to make this part of the `Quantity` class but it turned out that it's not easily doable.

One thing to remember: this will never replace `Quantity` because we still want to provide a consistent API for base devices. The `quantity` decorator should only be used for quantities that are not common to all devices of a certain base class (e.g. the `clock_cycles` of the Ufo camera).
