### PR TITLE
Don't drop the last exception by fake futures

### DIFF
--- a/concert/async.py
+++ b/concert/async.py
@@ -14,6 +14,7 @@
 
 """
 import functools
+import traceback
 import concert.config
 from concurrent.futures import ThreadPoolExecutor, Future
 
@@ -21,6 +22,14 @@ try:
     import Queue as queue
 except ImportError:
     import queue
+
+
+# Provide nicely formatted exceptions if possible
+_colored_exceptions = True
+try:
+    from IPython.core.ultratb import AutoFormattedTB
+except ImportError:
+    _colored_exceptions = False
 
 
 # Patch futures so that they provide a join() and kill() method
@@ -52,6 +61,10 @@ def no_async(func):
             result = func(*args, **kwargs)
             future.set_result(result)
         except Exception as e:
+            if _colored_exceptions:
+                AutoFormattedTB(mode='Verbose')()
+            else:
+                traceback.print_exc()
             future.set_exception(e)
 
         return future


### PR DESCRIPTION
Addresses #208. The problem is the exception origin is lost when it is re-raised by the future. This breaks the API, but disabling the asynchronous execution is anyway done only by debugging, and so I don't really care if `.join()` doesn't work as long as I see quickly where my exception comes from.
There are workarounds, e.g. via `sys.exc_info` and `traceback` module. We can print the stack trace of the last exception and then set the exception for the Future instance. But that seems to me like over-thinking a simple use case: to have a debug mode where one sees the origin of exception, which was the reason for `DISABLE_ASYNC` in the first place.
