### PR TITLE
Fix #209: Add AccessorNotImplementedError

### DIFF
--- a/concert/base.py
+++ b/concert/base.py
@@ -69,6 +69,11 @@ class ParameterError(Exception):
         super(ParameterError, self).__init__(msg)
 
 
+class AccessorNotImplementedError(NotImplementedError):
+
+    """Raised when a setter or getter is not implemented."""
+
+
 class ReadAccessError(Exception):
 
     """Raised when user tries to change a parameter that cannot be written."""
@@ -328,7 +333,7 @@ class Parameter(object):
                 value = getattr(instance, self.getter_name())(*self.data_args)
 
             return value
-        except NotImplementedError:
+        except AccessorNotImplementedError:
             raise ReadAccessError(self.name)
 
     def __set__(self, instance, value):
@@ -355,7 +360,7 @@ class Parameter(object):
                     func(value, *self.data_args)
                 else:
                     func(instance, value, *self.data_args)
-            except NotImplementedError:
+            except AccessorNotImplementedError:
                 raise WriteAccessError(self.name)
 
         log_access('set')
@@ -676,10 +681,10 @@ class Parameterizable(six.with_metaclass(MetaParameterizable, object)):
         self._params[name] = value
 
         def setter_not_implemented(value, *args):
-            raise NotImplementedError
+            raise AccessorNotImplementedError
 
         def getter_not_implemented(*args):
-            raise NotImplementedError
+            raise AccessorNotImplementedError
 
         setattr(self, 'set_' + name, value.set)
         setattr(self, 'get_' + name, value.get)

--- a/concert/devices/cameras/base.py
+++ b/concert/devices/cameras/base.py
@@ -48,7 +48,7 @@ To setup and use a camera in a typical environment, you would do::
     print("mean=%f, stddev=%f" % (np.mean(data), np.std(data))
 """
 import contextlib
-from concert.base import Parameter, Quantity, State, transition
+from concert.base import AccessorNotImplementedError, Parameter, Quantity, State, transition
 from concert.async import async
 from concert.quantities import q
 from concert.helpers import Bunch
@@ -122,22 +122,22 @@ class Camera(Device):
             consumer.send(self.grab())
 
     def _get_trigger_mode(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _set_trigger_mode(self, mode):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _record_real(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _stop_real(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _trigger_real(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _grab_real(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
 
 class BufferedMixin(Device):
@@ -151,4 +151,4 @@ class BufferedMixin(Device):
         return self._readout_real(*args, **kwargs)
 
     def _readout_real(self, *args, **kwargs):
-        raise NotImplementedError
+        raise AccessorNotImplementedError

--- a/concert/devices/controllers/motion/base.py
+++ b/concert/devices/controllers/motion/base.py
@@ -1,6 +1,6 @@
 """Motor Controller"""
+from concert.base import Parameter, AccessorNotImplementedError
 from concert.devices.base import Device
-from concert.base import Parameter
 
 
 class MotorController(Device):
@@ -12,4 +12,4 @@ class MotorController(Device):
         super(MotorController, self).__init__(params)
 
     def _get_motors(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError

--- a/concert/devices/io/base.py
+++ b/concert/devices/io/base.py
@@ -1,4 +1,5 @@
 """Port, IO Device."""
+from concert.base import AccessorNotImplementedError
 from concert.devices.base import Device
 
 
@@ -34,11 +35,11 @@ class IO(Device):
 
     def _read_port(self, port):
         """Implementation of reading a *port* from the device."""
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _write_port(self, port, value):
         """Implementation of writing a *value* to a *port* on the device."""
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
 
 class IODeviceError(Exception):

--- a/concert/devices/monochromators/base.py
+++ b/concert/devices/monochromators/base.py
@@ -4,7 +4,7 @@ setters for wither wavelength or energy, it does not matter which one. The
 conversion is handled in the base class.
 '''
 from concert.quantities import q
-from concert.base import Quantity
+from concert.base import Quantity, AccessorNotImplementedError
 from concert.devices.base import Device
 
 # pint supports constants and defines hbar like this, but I haven't found a way
@@ -46,35 +46,35 @@ class Monochromator(Device):
     def _get_energy(self):
         try:
             return self._get_energy_real()
-        except NotImplementedError:
+        except AccessorNotImplementedError:
             return wavelength_to_energy(self._get_wavelength_real())
 
     def _set_energy(self, energy):
         try:
             return self._set_energy_real(energy)
-        except NotImplementedError:
+        except AccessorNotImplementedError:
             self._set_wavelength_real(energy_to_wavelength(energy))
 
     def _get_wavelength(self):
         try:
             return self._get_wavelength_real()
-        except NotImplementedError:
+        except AccessorNotImplementedError:
             return energy_to_wavelength(self._get_energy_real())
 
     def _set_wavelength(self, wavelength):
         try:
             self._set_wavelength_real(wavelength)
-        except NotImplementedError:
+        except AccessorNotImplementedError:
             self._set_energy_real(wavelength_to_energy(wavelength))
 
     def _get_energy_real(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _set_energy_real(self, energy):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _get_wavelength_real(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _set_wavelength_real(self, wavelength):
-        raise NotImplementedError
+        raise AccessorNotImplementedError

--- a/concert/devices/motors/base.py
+++ b/concert/devices/motors/base.py
@@ -16,7 +16,7 @@ As long as an motor is moving, :meth:`Motor.stop` will stop the motion.
 import logging
 from concert.quantities import q
 from concert.async import async
-from concert.base import Quantity, State, transition
+from concert.base import Quantity, State, transition, AccessorNotImplementedError
 from concert.devices.base import Device
 
 
@@ -58,10 +58,10 @@ class _PositionMixin(Device):
         self._home()
 
     def _home(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _stop(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
 
 class LinearMotor(_PositionMixin):

--- a/concert/devices/pumps/base.py
+++ b/concert/devices/pumps/base.py
@@ -1,6 +1,6 @@
 """Pumps."""
 
-from concert.base import Quantity, State, transition
+from concert.base import Quantity, State, transition, AccessorNotImplementedError
 from concert.quantities import q
 from concert.async import async
 from concert.devices.base import Device
@@ -41,10 +41,10 @@ class Pump(Device):
         self._stop()
 
     def _get_flow_rate(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _set_flow_rate(self, flow_rate):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _start(self):
         raise NotImplementedError

--- a/concert/devices/scales/base.py
+++ b/concert/devices/scales/base.py
@@ -1,7 +1,7 @@
 """Base scales module for implementing scales."""
 
 from concert.devices.base import Device
-from concert.base import Quantity
+from concert.base import Quantity, AccessorNotImplementedError
 from concert.quantities import q
 from concert.async import async
 
@@ -23,7 +23,7 @@ class Scales(Device):
         super(Scales, self).__init__()
 
     def _get_weight(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
 
 class TarableScales(Scales):
@@ -39,4 +39,4 @@ class TarableScales(Scales):
         self._tare()
 
     def _tare(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError

--- a/concert/devices/shutters/base.py
+++ b/concert/devices/shutters/base.py
@@ -1,5 +1,5 @@
 """Shutter Device."""
-from concert.base import transition, State
+from concert.base import transition, State, AccessorNotImplementedError
 from concert.async import async
 from concert.devices.base import Device
 
@@ -30,7 +30,7 @@ class Shutter(Device):
         self._close()
 
     def _open(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _close(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError

--- a/concert/devices/storagerings/base.py
+++ b/concert/devices/storagerings/base.py
@@ -1,6 +1,6 @@
 """Storage Ring Device"""
 from concert.quantities import q
-from concert.base import Quantity
+from concert.base import Quantity, AccessorNotImplementedError
 from concert.devices.base import Device
 
 
@@ -28,10 +28,10 @@ class StorageRing(Device):
         super(StorageRing, self).__init__()
 
     def _get_current(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _get_energy(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError
 
     def _get_lifetime(self):
-        raise NotImplementedError
+        raise AccessorNotImplementedError

--- a/concert/tests/regressions/test_209.py
+++ b/concert/tests/regressions/test_209.py
@@ -1,29 +1,48 @@
+from concert.tests import TestCase
 from concert.quantities import q
 from concert.devices.motors.base import RotationMotor as BaseRotationMotor
 from concert.devices.motors.dummy import RotationMotor
- 
- 
-class BreakingMotor(BaseRotationMotor):
+
+
+class ImproperlyImplemented(BaseRotationMotor):
     def __init__(self):
-        super(BreakingMotor, self).__init__()
+        super(ImproperlyImplemented, self).__init__()
         self._value = 0
-     
+
     def _get_position(self):
         return self._value
-     
+
     def _set_position(self, value):
         self._value = value
 
+
+class BreakingMotor(ImproperlyImplemented):
+    def __init__(self):
+        super(BreakingMotor, self).__init__()
+
     def check_state(self):
         return 'standby'
- 
- 
-def test_issue_209():
-    dummy = RotationMotor()
-    fancy = BreakingMotor()
 
-    dummy.position = 10 * q.deg
-    assert dummy.position == 10 * q.deg
 
-    fancy.position = 20 * q.deg
-    assert fancy.position == 20 * q.deg
+class TestIssue209(TestCase):
+
+    def test_method_not_implemented(self):
+        """
+        Although required by base.RotationMotor, the BreakingMotor does not
+        implement check_state but rather than telling us that, it says that the
+        parameter cannot be written.
+        """
+        fancy = ImproperlyImplemented()
+
+        with self.assertRaises(NotImplementedError):
+            fancy.position = 20 * q.deg
+
+    def test_shared_parameters(self):
+        dummy = RotationMotor()
+        fancy = BreakingMotor()
+
+        dummy.position = 10 * q.deg
+        self.assertEqual(dummy.position, 10 * q.deg)
+
+        fancy.position = 20 * q.deg
+        self.assertEqual(fancy.position, 20 * q.deg)

--- a/docs/devel/reference/core.rst
+++ b/docs/devel/reference/core.rst
@@ -56,6 +56,7 @@ Exceptions
 .. autoclass:: concert.base.UnitError
 .. autoclass:: concert.base.LimitError
 .. autoclass:: concert.base.ParameterError
+.. autoclass:: concert.base.AccessorNotImplementedError
 .. autoclass:: concert.base.ReadAccessError
 .. autoclass:: concert.base.WriteAccessError
 

--- a/docs/devel/tutorial.rst
+++ b/docs/devel/tutorial.rst
@@ -101,7 +101,7 @@ which belong to our new device, in our case the ``position``::
             self['position'].conversion = lambda x: x * 20 * q.count / q.mm
 
 Now, all that's left to do, is implementing the abstract methods that would
-raise a :exc:`NotImplementedError`::
+raise a :exc:`.AccessorNotImplementedError`::
 
         def _get_position(self):
             return self.steps
@@ -169,6 +169,17 @@ explicit setters and getters in order to hook into the get and set process::
 
 Be aware, that in this case you have to list the parameter *after* the functions
 that you want to refer to.
+
+In case you want to specify the name of the accessor function yourself and rely
+on implementation by subclasses, you have to raise an
+:exc:`.AccessorNotImplementedError`::
+
+    class Pump(Device):
+
+        ...
+
+        def _set_flow_rate(self):
+            raise AccessorNotImplementedError
 
 
 State machine


### PR DESCRIPTION
Setters and getters that are not implemented by base devices must now raise this instead of a `NotImplementedError` in order to avoid problems when turning them into `ReadAccessError` and `WriteAccessError`.

This should fix part 2 of #209.
