### PR TITLE
Make recording context exception-safe

### DIFF
--- a/concert/devices/cameras/base.py
+++ b/concert/devices/cameras/base.py
@@ -99,8 +99,10 @@ class Camera(Device):
                 frame = camera.grab()
         """
         self.start_recording()
-        yield
-        self.stop_recording()
+        try:
+            yield
+        finally:
+            self.stop_recording()
 
     def trigger(self):
         """Trigger a frame if possible."""


### PR DESCRIPTION
The camera is back in the `standby` state if some exception occurs in the `with camera.recording()` block. If @matze didn't have a special reason to do it without exception handling we are good to go.
