### PR TITLE
[WIP] Add kiro-based camera

### DIFF
--- a/concert/devices/cameras/kiro.py
+++ b/concert/devices/cameras/kiro.py
@@ -4,19 +4,14 @@ from concert.devices.cameras import uca
 
 class Camera(base.Camera):
 
-    def __init__(self, ip=None, port=None):
+    def __init__(self, ip, port):
         super(Camera, self).__init__()
 
-        self._uca_camera = uca.Camera('kiro')
         self._tango_camera = None
+        # fetch properties from remote camera
 
-        if ip and port:
-            self.connect(ip, port)
-
-    def connect(self, ip, port):
+        self._uca_camera = uca.Camera('kiro')
         self._uca_camera.set_properties(ip=ip, port=port)
-        # Here we also need to get the properties from the tango device and map
-        # them to device properties.
 
     def _record_real(self):
         pass    # use tango


### PR DESCRIPTION
Since Friday, there is a working InfiniBand-RDMA implementation of a camera by @TimoDritschler called Kiro (I forgot what that stands for ;-)). Just to summarize, here's how it works:
- Timo built a small GObjectified library Kiro for InfiniBand-RDMA communication.
- The existing UcaDevice server which uses libuca to talk to cameras was pimped and allows a secondary data connection using the Kiro-library.
- A libuca camera plugin that uses Kiro on the client side was developed.

Thus we can have many possibilities how to use it, but the one in the Concert context would look like this:

```
Camera -> libuca -> TANGO-Kiro -> Kiro-Client -> libuca -> Concert
                        |                                     ^
                        +--------------- Tango ---------------+
```

This is quite a pipeline, so it is obvious that we need to wrap it and that's what this PR is for.

When writing this there was one immediate question to me: Should we allow run-time customization of the camera, i.e. re-connecting to a different IP? I can imagine that this requires quite some effort to remove and rebuild the parameter table.

In any case, whoever feels confident with TANGO might add the bits for control.
