### PR TITLE
Use real hardware state in uca cameras

### DIFF
--- a/concert/devices/cameras/pco.py
+++ b/concert/devices/cameras/pco.py
@@ -25,6 +25,12 @@ class Pco(Camera):
 
         return super(Pco, self).stream(consumer)
 
+    def _get_state(self):
+        if self.uca.props.is_recording:
+            return 'recording'
+        else:
+            return 'standby'
+
 
 class PCO4000(Pco):
 
@@ -92,6 +98,12 @@ class Dimax(Pco, base.BufferedMixin):
             raise StopIteration
         finally:
             self.uca.stop_readout()
+
+    def _get_state(self):
+        if self.uca.props.is_readout:
+            return 'readout'
+        else:
+            return super(Dimax, self)._get_state()
 
 
 class Timestamp(object):

--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import numpy as np
 from concert.quantities import q
-from concert.base import Parameter, Quantity, transition
+from concert.base import Parameter, Quantity
 from concert.helpers import Bunch
 from concert.devices.cameras import base
 
@@ -161,14 +161,12 @@ class Camera(base.Camera):
         uca_value = getattr(self.uca.enum_values.trigger_mode, mode)
         self._uca_set_trigger(self, uca_value)
 
-    @transition(target='recording')
     @_translate_gerror
     def _record_real(self):
         self._record_shape = self.roi_height.magnitude, self.roi_width.magnitude
         self._record_dtype = np.uint16 if self.sensor_bitdepth.magnitude > 8 else np.uint8
         self.uca.start_recording()
 
-    @transition(target='standby')
     @_translate_gerror
     def _stop_real(self):
         self.uca.stop_recording()


### PR DESCRIPTION
I tried it already with Dimax and it works. Now when the camera stops recording on its own users can see that by `camera.state`.
