### PR TITLE
Allow hard-limit target state when homing a motor

### DIFF
--- a/concert/devices/motors/base.py
+++ b/concert/devices/motors/base.py
@@ -48,7 +48,7 @@ class _PositionMixin(Device):
         self._stop()
 
     @async
-    @check(source='*', target='standby')
+    @check(source='*', target=['standby', 'hard-limit'])
     def home(self):
         """
         home()


### PR DESCRIPTION
Apparently, this is _the_ correct behavior, it is pretty deep so I think that even just one tiny line deserves a PR.
