### PR TITLE
Fix #353: Prevent changing parameters while recording

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -15,10 +15,9 @@ LOG = logging.getLogger(__name__)
 
 def _new_setter_wrapper(name, unit=None):
     def _wrapper(instance, value):
-        if instance:
-            if instance.state == 'recording':
-                raise base.CameraError(
-                'Changing parameters is not allowed while recording')
+        if instance.state == 'recording':
+            raise base.CameraError(
+            'Changing parameters is not allowed while recording')
 
         if unit:
             value = value.to(unit)

--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -15,6 +15,11 @@ LOG = logging.getLogger(__name__)
 
 def _new_setter_wrapper(name, unit=None):
     def _wrapper(instance, value):
+        if instance:
+            if instance.state == 'recording':
+                raise base.CameraError(
+                'Changing parameters is not allowed while recording')
+
         if unit:
             value = value.to(unit)
 


### PR DESCRIPTION
Should 'fix' #353 by not allowing to change any parameter while recording, in the first place.