### PR TITLE
[WIP] Print exceptions of async calls

### DIFF
--- a/concert/async.py
+++ b/concert/async.py
@@ -215,7 +215,8 @@ if not concert.config.ENABLE_GEVENT or not HAVE_GEVENT:
                 @functools.wraps(func)
                 def _inner(*args, **kwargs):
                     future = EXECUTOR.submit(func, *args, **kwargs)
-                    future.add_done_callback(print_exception)
+                    if concert.config.ENABLE_PRINT_ASYNC_EXCEPTION:
+                        future.add_done_callback(print_exception)
                     return future
 
                 return _inner

--- a/concert/async.py
+++ b/concert/async.py
@@ -214,7 +214,9 @@ if not concert.config.ENABLE_GEVENT or not HAVE_GEVENT:
             if concert.config.ENABLE_ASYNC:
                 @functools.wraps(func)
                 def _inner(*args, **kwargs):
-                    return EXECUTOR.submit(func, *args, **kwargs)
+                    future = EXECUTOR.submit(func, *args, **kwargs)
+                    future.add_done_callback(print_exception)
+                    return future
 
                 return _inner
             else:
@@ -230,6 +232,10 @@ if not concert.config.ENABLE_GEVENT or not HAVE_GEVENT:
                 return thread
 
             return wrapper
+
+        def print_exception(future):
+            if future.exception() is not None:
+                print future.exception()
 
 
 def wait(futures):

--- a/concert/async.py
+++ b/concert/async.py
@@ -179,6 +179,8 @@ if concert.config.ENABLE_GEVENT:
                 @functools.wraps(func)
                 def _inner(*args, **kwargs):
                     g = GreenletFuture(func, args, kwargs)
+                    if concert.config.ENABLE_PRINT_ASYNC_EXCEPTION:
+                        g.link(print_exception)
                     g.start()
                     return g
 
@@ -193,6 +195,11 @@ if concert.config.ENABLE_GEVENT:
                 return result
 
             return _inner
+
+        def print_exception(g):
+            if g.saved_exception is not None:
+                print g.saved_exception
+
     except ImportError:
         HAVE_GEVENT = False
         print("Gevent is not available, falling back to threads")

--- a/concert/config.py
+++ b/concert/config.py
@@ -8,7 +8,12 @@
 
     Turn on gevent support. If geven is not available, fall back to
     ThreadPoolExecutor approach.
+
+.. data:: ENABLE_PRINT_ASYNC_EXCEPTION
+
+    If enabled exceptions from async functions will be printed.
 """
 
 ENABLE_ASYNC = True
 ENABLE_GEVENT = False
+ENABLE_PRINT_ASYNC_EXCEPTION = True


### PR DESCRIPTION
A callback will print exceptions of async functions.
This can be enabled and disabled via concert.config.ENABLE_PRINT_ASYNC_EXCEPTION.
