### PR TITLE
Don't use upper bound on `measure` test duration

### DIFF
--- a/concert/tests/unit/test_helpers.py
+++ b/concert/tests/unit/test_helpers.py
@@ -93,4 +93,3 @@ def test_measure_execution():
     result, elapsed = sleeping()
     assert(result == 123)
     assert(elapsed > 0.001 * q.s)
-    assert(elapsed < 0.010 * q.s)


### PR DESCRIPTION
Sometimes it is more than those 10 milliseconds.