### PR TITLE
Add Flask-like extension system

### DIFF
--- a/concert/exthook.py
+++ b/concert/exthook.py
@@ -1,0 +1,45 @@
+"""
+Extension hook system based on Flask's exthook.py, originally written by Armin
+Ronacher and licensed under BSD license.
+"""
+
+
+import sys
+import os
+
+
+class ExtensionImporter(object):
+
+    def __init__(self, wrapper_module):
+        self.wrapper_module = wrapper_module
+        self.prefix = wrapper_module + '.'
+        self.prefix_cutoff = wrapper_module.count('.') + 1
+
+    def __eq__(self, other):
+        return self.__class__.__module__ == other.__class__.__module__ and \
+               self.__class__.__name__ == other.__class__.__name__ and \
+               self.wrapper_module == other.wrapper_module
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def install(self):
+        sys.meta_path[:] = [x for x in sys.meta_path if self != x] + [self]
+
+    def find_module(self, fullname, path=None):
+        if fullname.startswith(self.prefix):
+            return self
+
+    def load_module(self, fullname):
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+        modname = fullname.split('.', self.prefix_cutoff)[self.prefix_cutoff]
+        realname = 'concert_{}'.format(modname)
+        __import__(realname)
+        module = sys.modules[fullname] = sys.modules[realname]
+
+        if '.' not in modname:
+            setattr(sys.modules[self.wrapper_module], modname, module)
+
+        return module
+        raise ImportError('No module named %s' % fullname)

--- a/concert/third/__init__.py
+++ b/concert/third/__init__.py
@@ -1,0 +1,9 @@
+def setup():
+    from ..exthook import ExtensionImporter
+    importer = ExtensionImporter(__name__)
+    importer.install()
+
+
+setup()
+del setup
+

--- a/docs/devel/extensions.rst
+++ b/docs/devel/extensions.rst
@@ -1,0 +1,27 @@
+==========
+Extensions
+==========
+
+Concert allows third-party extensions to reside under a common namespace
+``concert.third.*`` similar to the Flask extension system. To achieve this,
+extensions must be modules or packages named ``concert_name`` and be installed
+with setuptools like this::
+
+    from setuptools import setup
+
+    setup(
+        name='Concert-Foo',
+        version='1.0',
+        url='...',
+        author='...',
+        py_modules=['concert_foo'],
+        zip_safe=False,
+        install_requires=[
+            'concert',
+        ]
+    )
+
+After successful installation, the user can import a third-party extension
+simply like this::
+
+    from concert.third.foo import SomeClass, some_func

--- a/docs/devel/topics.rst
+++ b/docs/devel/topics.rst
@@ -8,4 +8,5 @@ Development
     tutorial
     async
     helpers
+    extensions
     contrib


### PR DESCRIPTION
This allows third-party extensions to be imported from a common namespace. By
ensuring use of setuptools we can also enforce proper versioning and deployment
strategies.