### PR TITLE
Generalize acquisitions

### DIFF
--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -16,11 +16,11 @@ class Acquisition(object):
     """
     An acquisition acquires data, gets it and sends it to consumers.
 
-    .. py:attribute:: generator_caller
+    .. py:attribute:: producer
 
         a callable with no arguments which returns a generator yielding data items once called.
 
-    .. py:attribute:: consumer_callers
+    .. py:attribute:: consumers
 
         a list of callables with no arguments which return a coroutine consuming the data once
         started, can be empty.
@@ -31,10 +31,10 @@ class Acquisition(object):
 
     """
 
-    def __init__(self, name, generator_caller, consumer_callers=None, acquire=None):
+    def __init__(self, name, producer, consumers=None, acquire=None):
         self.name = name
-        self.generator = generator_caller
-        self.consumers = [] if consumer_callers is None else consumer_callers
+        self.producer = producer
+        self.consumers = [] if consumers is None else consumers
         # Don't bother with checking this for None later
         self.acquire = acquire if acquire else lambda: None
 
@@ -44,7 +44,7 @@ class Acquisition(object):
         for not_started in self.consumers:
             started.append(not_started())
 
-        inject(self.generator(), broadcast(*started))
+        inject(self.producer(), broadcast(*started))
 
     def __call__(self):
         """Run the acquisition, i.e. acquire the data and connect the producer and consumers."""

--- a/concert/tests/integration/test_experiments.py
+++ b/concert/tests/integration/test_experiments.py
@@ -54,7 +54,7 @@ class TestAcquisition(TestCase):
     def setUp(self):
         self.acquired = False
         self.item = None
-        self.acquisition = Acquisition('foo', self.produce, consumer_callers=[self.consume],
+        self.acquisition = Acquisition('foo', self.produce, consumers=[self.consume],
                                        acquire=self.acquire)
 
     def test_connect(self):
@@ -95,7 +95,7 @@ class TestExperimentBase(TestCase):
         self.walker = DummyWalker(root=self.root)
         self.name_fmt = 'scan_{:>04}'
         self.visited = 0
-        self.foo = Acquisition("foo", self.produce, consumer_callers=[self.consume],
+        self.foo = Acquisition("foo", self.produce, consumers=[self.consume],
                                acquire=self.acquire)
         self.bar = Acquisition("bar", self.produce, acquire=self.acquire)
         self.acquisitions = [self.foo, self.bar]

--- a/docs/user/topics/experiments.rst
+++ b/docs/user/topics/experiments.rst
@@ -66,6 +66,32 @@ running the acquisition above and storing log with
     :members:
 
 
+Advanced
+--------
+
+Sometimes we need finer control over when exactly is the data acquired and worry
+about the download later. We can use the *acquire* argument to
+:class:`~.base.Acquisition`. This means that the data acquisition can be invoked
+independently from the processing stage. By default, the
+:class:`~.base.Acquisition` calls its *acquire* and then connects the processing
+immediately. To use the separate acquisition we may e.g. reimplement the
+:meth:`.base.Experiment.acquire` method::
+
+    class SplitExperiment(Experiment):
+
+        def acquire(self):
+            # Here we acquire
+            for acq in self.acquisitions:
+                acq.acquire()
+
+            # Do something in between
+            pass
+
+            # Here we process
+            for acq in self.acquisitions:
+                acq.connect()
+
+
 Imaging
 -------
 


### PR DESCRIPTION
It makes sense to split data acquisition and download. Especially when one wants to acquire all the data at once (e.g. fill up a camera buffer with different frame types by external trigger) and worry about the download later.