### PR TITLE
Fixes relative paths in DirectoryWalker

### DIFF
--- a/concert/storage.py
+++ b/concert/storage.py
@@ -218,6 +218,7 @@ class DirectoryWalker(Walker):
         """
         if not root:
             root = os.getcwd()
+        root = os.path.abspath(root)
 
         log_handler = None
 


### PR DESCRIPTION
When using a relative path as 'root' a change of the current directory in the session caused a wrong behavior when descending.

Example:
* current directory: ~
* Creating a DirectoryWalker with root='data'
* Running experiments -> scan_X created in ~/data
* cd data
* Running next experiment: New directory data/scan_X+1 is created inside data, but DirectoryWalker.current points to ~/data/scan_X+1

Using only absolute paths as 'root' should fix this.
