### PR TITLE
Numpy accumulate

### DIFF
--- a/concert/coroutines/sinks.py
+++ b/concert/coroutines/sinks.py
@@ -34,21 +34,41 @@ def null():
 
 
 class Accumulate(object):
-    """Accumulate items in a list."""
+    """Accumulate items in a list or a numpy array if *shape* is given, *dtype* is the data type.
+    """
 
-    def __init__(self):
-        self.items = []
+    def __init__(self, shape=None, dtype=None):
+        import numpy as np
 
-    @coroutine
+        self.items = [] if shape is None else np.empty(shape, dtype=dtype)
+
     def __call__(self):
         """
         __call__(self)
 
         Coroutine interface for processing in a pipeline.
         """
+        if isinstance(self.items, list):
+            return self._process()
+        else:
+            return self._process_numpy()
+
+    @coroutine
+    def _process(self):
+        """Stack data into a list."""
         # Clear results from possible previous execution
         self.items = []
 
         while True:
             item = yield
             self.items.append(item)
+
+    @coroutine
+    def _process_numpy(self):
+        """Stack data into a numpy array."""
+        i = 0
+
+        while True:
+            item = yield
+            self.items[i] = item
+            i += 1

--- a/concert/tests/unit/test_coroutines.py
+++ b/concert/tests/unit/test_coroutines.py
@@ -152,9 +152,20 @@ class TestCoroutines(TestCase):
         frame_producer(backproject(1, null()))
 
     def test_accumulate(self):
-        accumulate = Accumulate()
-        inject(generator(), accumulate())
-        self.assertEqual(accumulate.items, range(5))
+        def run_test(data, shape=None, dtype=None):
+            accumulate = Accumulate(shape=shape, dtype=dtype)
+            inject(data, accumulate())
+            np.testing.assert_equal(accumulate.items, data)
+            target_type = np.ndarray if shape else list
+            self.assertTrue(isinstance(accumulate.items, target_type))
+            if shape:
+                self.assertEqual(accumulate.items.dtype, data.dtype)
+
+        shape = (4, 4, 4)
+        dtype = np.ushort
+        data = np.ones(shape, dtype=dtype)
+        run_test(data)
+        run_test(data, shape=shape, dtype=dtype)
 
     def test_process(self):
         result = Result()


### PR DESCRIPTION
It will be very convenient to have the data accumulated already as a numpy ND stack when implementing general backprojectors or data processing routines in general. With this we can do for example `backproject.insert(accumulate.items[:, height, :])` which wouldn't be so simple AFAIK with a list of 2D numpy arrays.