### PR TITLE
Accumulate addon

### DIFF
--- a/concert/coroutines/sinks.py
+++ b/concert/coroutines/sinks.py
@@ -56,8 +56,8 @@ class Accumulate(object):
     @coroutine
     def _process(self):
         """Stack data into a list."""
-        # Clear results from possible previous execution
-        self.items = []
+        # Clear results from possible previous execution but keep the list in the same place
+        del self.items[:]
 
         while True:
             item = yield


### PR DESCRIPTION
Stores experiment data so one can easily and efficiently access all of it as numpy arrays.

Todo:
* [x] make the interface more compact
* [x] make sure memory is released on `detach`

Requires #376. With this addon we can do:
```python
ex = Experiment(...)
acc = Accumulator(ex.acquisitions)
ex.run().join()
backproject.insert(acc.items[ex.radios][:, height, :])
```