### PR TITLE
Print noasync traceback

### DIFF
--- a/concert/async.py
+++ b/concert/async.py
@@ -79,6 +79,7 @@ def no_async(func):
             result = func(*args, **kwargs)
             future.set_result(result)
         except Exception as e:
+            traceback.print_exc()
             future.set_exception(e)
 
         return future

--- a/concert/async.py
+++ b/concert/async.py
@@ -80,7 +80,8 @@ def no_async(func):
             result = func(*args, **kwargs)
             future.set_result(result)
         except Exception as e:
-            traceback.print_exc()
+            if concert.config.PRINT_NOASYNC_EXCEPTION:
+                traceback.print_exc()
             future.set_exception(e)
 
         return future

--- a/concert/async.py
+++ b/concert/async.py
@@ -15,6 +15,7 @@
 """
 import time
 import functools
+import traceback
 import concert.config
 from concurrent.futures import ThreadPoolExecutor, Future
 from concert.quantities import q

--- a/concert/config.py
+++ b/concert/config.py
@@ -12,3 +12,5 @@
 
 ENABLE_ASYNC = True
 ENABLE_GEVENT = False
+# Prints the exception source by fake futures
+PRINT_NOASYNC_EXCEPTION = True

--- a/concert/ext/noseplugin.py
+++ b/concert/ext/noseplugin.py
@@ -14,6 +14,7 @@ class DisableAsync(nose.plugins.Plugin):
 
     def configure(self, options, conf):
         concert.config.ENABLE_ASYNC = not options.disable_async
+        concert.config.PRINT_NOASYNC_EXCEPTION = False
         super(DisableAsync, self).configure(options, conf)
 
 


### PR DESCRIPTION
Fixes #301 again and gives the possibility to suppress the exception source.