### PR TITLE
Fix potential segfault

### DIFF
--- a/concert/ext/ufo.py
+++ b/concert/ext/ufo.py
@@ -133,7 +133,7 @@ class InjectProcess(object):
         else:
             self.ufo_buffers[node][index] = self.input_tasks[node][index].get_input_buffer()
 
-        self.ufo_buffers[node][index].set_host_array(array.__array_interface__['data'][0], False)
+        self.ufo_buffers[node][index].copy_host_array(array.__array_interface__['data'][0])
         self.input_tasks[node][index].release_input_buffer(self.ufo_buffers[node][index])
 
     def result(self):


### PR DESCRIPTION
Passing the NumPy data pointer to the buffer does not work at least on one machine. Since this always seemed to be to brittle, we added a new call to ufo-core which allows data to be written to the host array. This means an additional data copy but this is effectively the same as in the very first version of the InjectProcess.

Note, though that this requires current HEAD (i.e. v0.10) of ufo-core.