### PR TITLE
Make parameter log output useful

### DIFF
--- a/bin/concert
+++ b/bin/concert
@@ -411,6 +411,7 @@ class StartCommand(Command):
             self.run_shell(module)
 
     def run_shell(self, module=None):
+        import concert
         from concert.base import (UnitError, LimitError, ParameterError,
                                   ReadAccessError, WriteAccessError, LockError)
 
@@ -435,6 +436,7 @@ class StartCommand(Command):
 
             if not module:
                 from concert.quantities import q
+            concert.base._get_instance_variable_name.memo = {}
 
             try:
                 shell = get_ipython_shell(config=config)


### PR DESCRIPTION
Currently, the parameter setting log output is useless. It only says which class changes a parameter. If we have e.g. many `LinearMotor` instances the output looks like this:

``` bash
concert.base: foo: set LinearMotor::position='12 millimeter'
```

This PR changes that to the following:

``` bash
concert.base: foo: set LinearMotor:name::position='12 millimeter'
```

where _name_ is the instance name, you would get it after typing `name = LinearMotor()` in your session.

The implementation is quite nasty but with a very elegant outcome, no additional attributes like `name` have to be added to devices, reducing the work of device developers and users to 0. I think it's worth it. What is @matze 's opinion?

@MarcusZuber could you test it at the lab please to see if it works as expected?
