### PR TITLE
Uca camera state read from camera

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -223,7 +223,7 @@ class Camera(base.Camera):
                               np.uint8)
 
     async def _get_state(self):
-        if self.uca.is_recording():
+        if self.uca.props.is_recording:
             return 'recording'
         elif self.uca.props.is_readout:
             return 'readout'


### PR DESCRIPTION
This reads the state of the camera from the uca device instead storing it in the local concert session.
This helps when using uca-net devices where the state can be out of sync to the state concert assumes.