### PR TITLE
Faster dummy camera

### DIFF
--- a/concert/devices/cameras/dummy.py
+++ b/concert/devices/cameras/dummy.py
@@ -92,13 +92,15 @@ class Camera(Base):
 
     """A simple dummy camera."""
 
-    def __init__(self, background=None):
+    def __init__(self, background=None, simulate=True):
         """
-        *background* can be an array-like that will be used to generate the frame
-        when calling :meth:`.grab`. The final image will be the background +
-        poisson noise depending on the currently set exposure time.
+        *background* can be an array-like that will be used to generate the frame when calling
+        :meth:`.grab`. If *simulate* is True the final image intensity will be scaled based on
+        exposure time and poisson noise will be added. If *simulate* is False, the background will
+        be returned with no modifications to it.
         """
         super(Camera, self).__init__()
+        self.simulate = simulate
 
         if background is not None:
             self.roi_width = background.shape[1] * q.pixel
@@ -110,6 +112,8 @@ class Camera(Base):
             self._background = np.ones(shape[::-1])
 
     def _grab_real(self):
+        if not self.simulate:
+            return self._background
         start = time.time()
         cur_time = self.exposure_time.to(q.s).magnitude
         # 1e5 is a dummy correlation between exposure time and emitted e-.

--- a/concert/tests/unit/devices/test_camera.py
+++ b/concert/tests/unit/devices/test_camera.py
@@ -11,7 +11,8 @@ class TestDummyCamera(TestCase):
 
     def setUp(self):
         super(TestDummyCamera, self).setUp()
-        self.camera = Camera()
+        self.background = np.ones((256, 256), dtype=np.uint16)
+        self.camera = Camera(background=self.background)
 
     def test_grab(self):
         frame = self.camera.grab()
@@ -71,6 +72,11 @@ class TestDummyCamera(TestCase):
         self.camera.convert = np.fliplr
         image = self.camera.grab()
         np.testing.assert_equal(image, grab()[:, ::-1])
+
+    def test_simulate(self):
+        self.assertTrue(np.any(self.background - self.camera.grab()))
+        camera = Camera(background=self.background, simulate=False)
+        np.testing.assert_equal(self.background, camera.grab())
 
 
 class TestPCOTimeStamp(TestCase):


### PR DESCRIPTION
Currently it takes 800 ms to simulate 2560 x 2160 images which is unacceptable.