### PR TITLE
add fraction and percent to quantities

### DIFF
--- a/concert/quantities.py
+++ b/concert/quantities.py
@@ -3,3 +3,6 @@ import pint
 q = pint.UnitRegistry()
 
 q.define('pixel = 1 * count = px')
+
+q.define('fraction = [] = frac')
+q.define('percent = 1e-2 frac = pct')


### PR DESCRIPTION
This adds percent as a unit to the quantities. We need this for a device where all parameters are set in percent.

@tfarago: From my side this should be fine and can be merged if no one disagrees.