### PR TITLE
Fix versions in requirements.txt to for python2.7 compatiblity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ nose==1.3.0
 prettytable==0.7.2
 pyxdg==0.26
 pint==0.5.2
-numpy
-scipy
+numpy==1.16.5
+scipy==1.2.2


### PR DESCRIPTION
The versions of the packages in requirements.txt are now fixed to the last versions that are compatible with python2.7. Otherwise setup.py installs packages for python3 and screws up the installation.