### PR TITLE
Ascan include last

### DIFF
--- a/concert/processes/common.py
+++ b/concert/processes/common.py
@@ -87,8 +87,8 @@ async def ascan(param, start, stop, step, feedback, go_back=False, include_last=
 
         scan(param, values, feedback=feedback, go_back=go_back))
     """
-    if start.units != stop.units or stop.units != step.units:
-        raise RuntimeError
+    stop = stop.to(start.units)
+    step = step.to(start.units)
     region = np.arange(start.magnitude, stop.magnitude, step.magnitude)
     if include_last:
         region = np.concatenate((region, [stop.magnitude]))

--- a/concert/tests/integration/test_scan.py
+++ b/concert/tests/integration/test_scan.py
@@ -45,6 +45,17 @@ class TestScan(TestCase):
         scanned = await run(include_last=False)
         compare_sequences(expected[:-1], scanned, assert_almost_equal)
 
+    async def test_ascan_units(self):
+        scanned = []
+        expected = [(0 * q.mm, 1 * q.dimensionless), (50 * q.mm, 1 * q.dimensionless),
+                    (100 * q.mm, 1 * q.dimensionless)]
+
+        async for pair in ascan(self.motor['position'], 0 * q.mm, 10 * q.cm,
+                                5 * q.cm, self.feedback):
+            scanned.append(pair)
+
+        compare_sequences(expected, scanned, assert_almost_equal)
+
     async def test_dscan(self):
         async def run(include_last=True):
             scanned = []


### PR DESCRIPTION
Allow endpoint of `ascan` and `dscan` to be included and relax unit requirements.