### PR TITLE
Enable running the loop from within a running loop

### DIFF
--- a/bin/concert
+++ b/bin/concert
@@ -1,9 +1,9 @@
 #! python
 
+import ast
 import asyncio
 import argparse
 import contextlib
-import functools
 import logging
 import os
 import re
@@ -12,7 +12,6 @@ import shutil
 import signal
 import subprocess
 import tempfile
-import traceback
 import zipfile
 import concert
 import concert.config
@@ -39,9 +38,11 @@ def cmp_versions(v1, v2):
     return (n1 > n2) - (n1 < n2)
 
 
-def get_prompt_config(session_name):
-    """Customize the prompt for the *session_name*."""
+def get_prompt_config(path):
+    """Customize the prompt for session in *path*."""
     from IPython.terminal.prompts import Prompts, Token
+
+    session_name = os.path.splitext(os.path.basename(path))[0]
 
     class MyPrompt(Prompts):
         def in_prompt_tokens(self, cli=None):
@@ -395,24 +396,36 @@ class StartCommand(SubCommand):
         sys.path.append(cs.path())
 
         if non_interactive:
+            import inspect
+
             if session:
-                exec(compile(open(cs.path(session), "rb").read(), cs.path(session), 'exec'), globals())
+                code_obj = compile(
+                    open(cs.path(session), "rb").read(),
+                    cs.path(session),
+                    'exec',
+                    flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+                )
+                eval_result = eval(code_obj, globals())
+                if inspect.iscoroutine(eval_result):
+                    loop = asyncio.get_event_loop()
+                    # More-or less a copy of asyncio.run() but with our loop
+                    try:
+                        loop.run_until_complete(eval_result)
+                    finally:
+                        to_cancel = asyncio.all_tasks(loop=loop)
+                        for task in to_cancel:
+                            task.cancel()
+                        loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+                        loop.run_until_complete(loop.shutdown_asyncgens())
+                        if hasattr(loop, 'shutdown_default_executor'):
+                            # Only in Python 3.9+
+                            loop.run_until_complete(loop.shutdown_default_executor())
         else:
-            try:
-                if filename:
-                    module = cs.load(filename, from_file=True)
-                else:
-                    module = cs.load(session) if session else None
-            except:
-                traceback.print_exc()
-                sys.exit(1)
+            self.run_shell(path=filename or cs.path(session) if session else None)
 
-            self.run_shell(module)
-
-    def run_shell(self, module=None):
-        from IPython.terminal.embed import InteractiveShellEmbed
-        from concert.base import (UnitError, LimitError, ParameterError,
-                                  ReadAccessError, WriteAccessError, LockError)
+    def run_shell(self, path=None):
+        import IPython
+        import traitlets.config
         from concert.session.utils import abort_awaiting
 
         # ctrl-c handling (abort whatever what is running in the foreground (blocks))
@@ -432,69 +445,32 @@ class StartCommand(SubCommand):
 
         signal.signal(signal.SIGINT, concert_sigint_handler)
 
-        def _handler(_shell, _etype, evalue, _traceback_, tb_offset=None):
-            if _etype == asyncio.CancelledError:
-                # Silently log the error message without polluting the terminal
-                messages = traceback.extract_tb(_traceback_).format()
-                if len(messages) > 1:
-                    messages = messages[1:]
-                LOG.info('asyncio.CancelledError\n' + ''.join(messages))
-            elif _etype == KeyboardInterrupt:
-                # Silently log the error message without polluting the terminal
-                messages = traceback.extract_tb(_traceback_).format()
-                if len(messages) > 2:
-                    # Skip IPython part and our sigint handler
-                    messages = messages[1:-1]
-                LOG.info('KeyboardInterrupt in normal mode\n' + ''.join(messages))
-            else:
-                print("Sorry, {0}".format(str(evalue)))
-            return None
-
-        def _abort_all_awaiting(event):
-            abort_awaiting(background=True)
-
         print("Welcome to Concert {0}".format(concert.__version__))
 
-        if module and module.__doc__:
-            print(module.__doc__)
+        if path:
+            with open(path) as session_file:
+                session_code = session_file.read()
+            tree = ast.parse(session_code)
+            docstring = ast.get_docstring(tree)
+            if docstring:
+                print(docstring)
+        else:
+            session_code = 'from concert.quantities import q'
 
-        try:
-            exceptions = (UnitError, LimitError, ParameterError, ReadAccessError, WriteAccessError,
-                          LockError, KeyboardInterrupt, asyncio.CancelledError)
+        ip_config = traitlets.config.Config()
+        ip_config.InteractiveShellApp.exec_lines = [session_code]
+        # This is the most robust way when taking virtualenv into account I have found so far
+        ip_config.InteractiveShellApp.exec_files = [os.path.join(concert.__path__[0],
+                                                                 '_ipython_setup.py')]
+        ip_config.TerminalInteractiveShell.prompts_class = get_prompt_config(path or 'concert')
+        ip_config.TerminalInteractiveShell.loop_runner = 'asyncio'
+        ip_config.TerminalInteractiveShell.autoawait = True
+        ip_config.InteractiveShell.confirm_exit = False
+        ip_config.TerminalIPythonApp.display_banner = False
+        ip_config.Completer.use_jedi = False
 
-            config = get_prompt_config(module.__name__) if module else get_prompt_config('concert')
-
-            if not module:
-                from concert.quantities import q
-
-            # commit 34b06dc92a6978296296a6489d61afc2619a49ef enables us to use "q" again but
-            # disables e.g. this:
-            # concert > import time
-            # concert > def foo():
-            #               time.sleep(1)
-            #               return True
-            # -> NameError: name 'time' is not defined
-            # TODO: fix this so that both things work
-            shell = InteractiveShellEmbed(banner1='', user_module=module)
-            # Tasks created with asyncio.ensure_future(...) are started immediately
-            shell.enable_gui(gui='asyncio')
-            shell.prompts = config(shell)
-            # jedi may invoke the code which creates a new event loop in prompt_toolkit which breaks
-            # things like sockets, which live throughout the session and thus rely on a single event
-            # loop. If this becomes unmaintainable, consider using trio or curio.
-            # To the code invocation: it happens mostly in descriptor access, e.g.
-            # motor.pos<Tab> invokes the motor.position in a new loop and that is not permissible
-            # within the simple SocketConnection class which internal state is bound to the loop
-            # within which it was created.
-            shell.Completer.use_jedi = False
-
-            shell.set_custom_exc(exceptions, _handler)
-            # ctrl-k (abort everything, also background awaitables)
-            shell.pt_app.key_bindings.add('c-k')(_abort_all_awaiting)
-            shell()
-        except ImportError as exception:
-            msg = "You must install IPython to run the Concert shell: {0}"
-            print(msg.format(exception))
+        # Now we start ipython with our configuration
+        IPython.start_ipython(argv=[], config=ip_config)
 
 
 class DocsCommand(SubCommand):

--- a/concert/_ipython_setup.py
+++ b/concert/_ipython_setup.py
@@ -1,0 +1,54 @@
+"""
+NEVER USE THIS MODULE DIRECTLY!
+
+The only use case of this module is with IPython's "exec_files" managed in bin/concert. The module
+contains IPython configuration which must be executed as code and cannot be passsed as config.
+"""
+import asyncio
+import logging
+import traceback
+from concert.base import (UnitError, LimitError, ParameterError,
+                          ReadAccessError, WriteAccessError, LockError)
+from concert.session.utils import abort_awaiting
+
+
+LOG = logging.getLogger(__name__)
+
+
+def _handler(_shell, _etype, evalue, _traceback_, tb_offset=None):
+    if _etype == asyncio.CancelledError:
+        # Silently log the error message without polluting the terminal
+        messages = traceback.extract_tb(_traceback_).format()
+        if len(messages) > 1:
+            messages = messages[1:]
+        LOG.info('asyncio.CancelledError\n' + ''.join(messages))
+    elif _etype == KeyboardInterrupt:
+        # Silently log the error message without polluting the terminal
+        messages = traceback.extract_tb(_traceback_).format()
+        if len(messages) > 2:
+            # Skip IPython part and our sigint handler
+            messages = messages[1:-1]
+        LOG.info('KeyboardInterrupt in normal mode\n' + ''.join(messages))
+    else:
+        print("Sorry, {0}".format(str(evalue)))
+    return None
+
+
+def _abort_all_awaiting(event):
+    abort_awaiting(background=True)
+
+
+_custom_exceptions = (
+    UnitError,
+    LimitError,
+    ParameterError,
+    ReadAccessError,
+    WriteAccessError,
+    LockError,
+    KeyboardInterrupt,
+    asyncio.CancelledError
+)
+ip = get_ipython()
+ip.set_custom_exc(_custom_exceptions, _handler)
+# ctrl-k (abort everything, also background awaitables)
+ip.pt_app.key_bindings.add('c-k')(_abort_all_awaiting)

--- a/concert/base.py
+++ b/concert/base.py
@@ -523,7 +523,7 @@ class ParameterValue(object):
         return self._parameter.name < other._parameter.name
 
     def __repr__(self):
-        return run_in_loop(self.info_table).get_string()
+        return run_in_loop_or_thread(self.info_table).get_string()
 
     @property
     async def info_table(self):
@@ -1022,7 +1022,7 @@ class Parameterizable(object):
                     self._install_parameter(attr_type)
 
     def __str__(self):
-        return run_in_loop(self.info_table).get_string(sortby="Parameter")
+        return run_in_loop_or_thread(self.info_table).get_string(sortby="Parameter")
 
     def __repr__(self):
         return '\n'.join([super(Parameterizable, self).__repr__(), str(self)])

--- a/concert/coroutines/base.py
+++ b/concert/coroutines/base.py
@@ -67,6 +67,25 @@ def run_in_loop_thread_blocking(coroutine):
         _TLOOP = None
 
 
+def run_in_loop_or_thread(coroutine):
+    """If the current event loop is running, run *coroutine* in a new event loop in a separate
+    thread by :func:`.run_in_loop_thread_blocking`, otherwise use :func:`.run_in_loop`. This is
+    useful for waiting for coroutines from non-async code and async-code without the need of being
+    async itself.
+    """
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        LOG.log(AIODEBUG,
+            'Loop already running, expediting %s to a thread',
+            coroutine.__qualname__
+        )
+        result = run_in_loop_thread_blocking(coroutine)
+    else:
+        result = run_in_loop(coroutine)
+
+    return result
+
+
 def run_in_executor(func, *args):
     """Run a blocking function *func* with signature func(\*args) in an executor."""
     # Leave this here for now, if there are problems with the normal run_in_executor returning a

--- a/concert/tests/unit/test_async_initialized.py
+++ b/concert/tests/unit/test_async_initialized.py
@@ -1,0 +1,214 @@
+import inspect
+from concert.base import AsyncInitialized, AsyncMeta
+from concert.tests import TestCase
+
+
+# Sync Inheritance Tree
+
+
+class SyncRoot:
+    def __init__(self, arg, kwarg=None):
+        self.sync_arg = arg
+        self.sync_kwarg = kwarg
+        self.sync_root_called = True
+
+
+class SyncClassA(SyncRoot):
+    def __init__(self, arg, kwarg=None):
+        self.arg = arg
+        self.kwarg = kwarg
+        self.sync_class_a_called = True
+        super().__init__(arg, kwarg=kwarg)
+
+
+class SyncClassB(SyncRoot):
+    def __init__(self, arg, kwarg=None):
+        self.arg = arg
+        self.kwarg = kwarg
+        self.sync_class_b_called = True
+        super().__init__(arg, kwarg=kwarg)
+
+
+class SyncClassC(SyncClassA, SyncClassB):
+    """Sync counterpart of AsyncClassC."""
+    def __init__(self, arg, kwarg=None):
+        self.arg = arg
+        self.kwarg = kwarg
+        self.sync_class_c_called = True
+        super().__init__(arg, kwarg=kwarg)
+
+
+# Async Inheritance Tree
+
+
+class AsyncRoot(AsyncInitialized):
+    async def __ainit__(self, arg, kwarg=None):
+        self.async_arg = arg
+        self.async_kwarg = kwarg
+        self.async_root_called = True
+
+
+class AsyncClassA(AsyncRoot):
+    async def __ainit__(self, arg, kwarg=None):
+        self.arg = arg
+        self.kwarg = kwarg
+        self.async_class_a_called = True
+        await super().__ainit__(arg, kwarg=kwarg)
+
+
+class AsyncClassB(AsyncRoot):
+    async def __ainit__(self, arg, kwarg=None):
+        self.arg = arg
+        self.kwarg = kwarg
+        self.async_class_b_called = True
+        await super().__ainit__(arg, kwarg=kwarg)
+
+
+class AsyncClassC(AsyncClassA, AsyncClassB):
+    """
+    Class with diamond inheritance for testing cooperative inheritance.
+
+    Topology:
+
+            AsyncInitialized
+                  |
+              AsyncRoot
+                 /\
+                /  \
+               /    \
+              /      \
+             /        \
+      AsyncClassA AsyncClassB
+             \        /
+              \      /
+               \    /
+                \  /
+                 \/
+             AsyncClassC
+    """
+
+    async def __ainit__(self, arg, kwarg=None):
+        self.arg = arg
+        self.kwarg = kwarg
+        self.async_class_c_called = True
+        await super().__ainit__(arg, kwarg=kwarg)
+
+
+class AsyncMixed(AsyncClassC, SyncClassC):
+    async def __ainit__(self):
+        super().__init__('sync', kwarg='skw')
+        await super().__ainit__('async', kwarg='akw')
+
+
+class AsyncMixedInverted(SyncClassC, AsyncClassC):
+    """Force mro to start with the sync classes, still everything must be initialized."""
+    async def __ainit__(self):
+        super().__init__('sync', kwarg='skw')
+        await super().__ainit__('async', kwarg='akw')
+
+
+# Tests
+
+
+class TestAsyncInitialized(TestCase):
+    async def test_new_class_init_defined(self):
+        """This must raise a TypeError."""
+        with self.assertRaises(TypeError):
+            # It doesn't matter that __init__ is not a function
+            AsyncMeta.__new__(AsyncMeta, 'Cls', (), {'__init__': ''})
+
+    async def test_custom_new(self):
+        """A full class where __new__ and __ainit__ must be called."""
+        class AsyncCustomNew(AsyncInitialized):
+            async def __ainit__(self, arg):
+                self.ainit_arg = arg
+
+            def __new__(cls, arg, *args, **kwargs):
+                obj = super().__new__(cls, *args, **kwargs)
+                obj.new_arg = arg + 1
+
+                return obj
+
+        obj = await AsyncCustomNew(0)
+        self.assertTrue(isinstance(obj, AsyncCustomNew))
+        self.assertEqual(obj.new_arg, 1)
+        self.assertEqual(obj.ainit_arg, 0)
+
+    async def test_not_isinstance_construction(self):
+        """A crippled class where __new__ is called but does not return an instance of its class."""
+        class NewNone(AsyncInitialized):
+            called = False
+
+            def __new__(cls, *args, **kwargs):
+                NewNone.called = True
+                return None
+
+        nn = await NewNone()
+        self.assertEqual(nn, None)
+        self.assertTrue(NewNone.called)
+
+    async def test_no_ainit_construction(self):
+        class NoAinit(metaclass=AsyncMeta):
+            pass
+
+        obj = await NoAinit()
+        self.assertTrue(isinstance(obj, NoAinit))
+
+    async def test_ainit_not_coroutinefunction(self):
+        class AsyncNotCoroutineFunction(AsyncInitialized):
+            def __ainit__(self):
+                async def foo():
+                    self.called = True
+
+                return foo()
+
+        obj = await AsyncNotCoroutineFunction()
+        self.assertTrue(obj.called)
+
+    async def test_ainit_not_awaitable(self):
+        class AsyncNotAwaitable(AsyncInitialized):
+            def __ainit__(self):
+                pass
+
+        with self.assertRaises(TypeError):
+            await AsyncNotAwaitable()
+
+    async def test_ainit_returns(self):
+        class AsyncReturning(AsyncInitialized):
+            async def __ainit__(self):
+                return 0
+
+        with self.assertRaises(TypeError):
+            await AsyncReturning()
+
+    async def test_trivial_construction(self):
+        """Just and empty class even without an __ainit__."""
+        coro = AsyncInitialized()
+        self.assertTrue(inspect.isawaitable(coro))
+        self.assertTrue(isinstance(await coro, AsyncInitialized))
+
+    async def test_normal_construction(self):
+        obj = await AsyncClassA(1, kwarg='kw')
+        self.assertEqual(obj.arg, 1)
+        self.assertEqual(obj.kwarg, 'kw')
+
+    async def test_inheritance(self):
+        async def _test_class(cls):
+            obj = await cls()
+            self.assertTrue(obj.async_class_a_called)
+            self.assertTrue(obj.async_class_b_called)
+            self.assertTrue(obj.async_class_c_called)
+            self.assertTrue(obj.async_root_called)
+
+            self.assertTrue(obj.sync_class_a_called)
+            self.assertTrue(obj.sync_class_b_called)
+            self.assertTrue(obj.sync_class_c_called)
+            self.assertTrue(obj.sync_root_called)
+
+            self.assertEqual(obj.sync_arg, 'sync')
+            self.assertEqual(obj.sync_kwarg, 'skw')
+            self.assertEqual(obj.async_arg, 'async')
+            self.assertEqual(obj.async_kwarg, 'akw')
+
+        await _test_class(AsyncMixed)
+        await _test_class(AsyncMixedInverted)


### PR DESCRIPTION
Which allows us to execute async code in a loop explicitly even when we
are an async code. It is now possible to run device.param = 'foo' from
both, non-async code and async-code. In short, this is possible:

## Version 1
```python
class MyDevice(Device):
    foo = Parameter()

    def __init__(self, value=1):
        super().__init__()
        self._foo = None
        self.foo = value

    async def _set_foo(self, value):
        self._foo = value

    async def _get_foo(self):
        return self._foo


async def factory():
    # This would have failed before with a RuntimeError: loop already running
    return MyDevice(value='from factory')

md = MyDevice()
```

## Alternative: version 2
```python
class MyDevice(Device):
    foo = Parameter()

    def __init__(self):
        super().__init__()
        self._foo = None

    @classmethod
    async def create(cls, value=1):
        self = MyDevice()
        await self.set_foo(value)

        return self

    async def _set_foo(self, value):
        self._foo = value

    async def _get_foo(self):
        return self._foo

async def factory():
    # This would have failed before with a RuntimeError: loop already running
    return await MyDevice.create(value='from factory')

md = run_in_loop(MyDevice.create())
```
## Alternative: version 3

We can add `__ainit__` to `Parameterizable`. If the child class implements `__ainit__`, it will be `RuntimeError` to try to construct the object directly via `MyClass()`, one will be *forced* to use `await MyDevice.ainit()`.

```python
class MyDevice(Device):
    foo = Parameter()

    def __init__(self):
        super().__init__()
        self._foo = None

    async def __ainit__(self, value=1):
        await self.set_foo(value)

    async def _set_foo(self, value):
        self._foo = value

    async def _get_foo(self):
        return self._foo

md = MyDevice() # RuntimeError
md = run_in_loop(MyDevice.ainit(value='from session'))
```

If we want this, we *must*
- [ ] check if [nest-asyncio](https://pypi.org/project/nest-asyncio/) wouldn't be a better option, especially because real devices could tie themselves to the event loop in the main thread (which tango does) and that would need to be handled for all device types (for tango it is inside ankaconcert)
- [ ] check thoroughly with real devices (tango, ...)
- [ ] test this _truly heavily_ inside concert
- [ ] make sure that all relevant occasions (especially in `concert.base`) of `run_in_loop` are replaced by this