### PR TITLE
fix nose for python3.10

### DIFF
--- a/concert/tests/__init__.py
+++ b/concert/tests/__init__.py
@@ -3,6 +3,9 @@ import logging
 import unittest
 import numpy as np
 
+import collections
+collections.Callable = collections.abc.Callable
+
 
 def slow(func):
     """Mark a test method as slow running.


### PR DESCRIPTION
Somewhere between python3.9 and 3.10 nose does not work anymore.

Nose also stopped development in 2015 and we should think of moving to nose2 or another test framework.

This fixes the current issue of the old nose implementation for now.
