### PR TITLE
Generalize unit of flatfield_position and radio_position of imaging experiments

### DIFF
--- a/concert/experiments/imaging.py
+++ b/concert/experiments/imaging.py
@@ -86,24 +86,17 @@ class Radiography(Experiment):
     num_projections = Parameter()
     """Number of projection images."""
 
-    radio_position = Quantity(q.mm)
-    """Position of the flat_motor to acquire projection images of the sample."""
-
-    flat_position = Quantity(q.mm)
-    """Position of the flat_motor to acquire images without the sample."""
-
     async def __ainit__(self, walker, flat_motor, radio_position, flat_position, camera, num_flats,
                         num_darks, num_projections, separate_scans=True):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param num_flats: Number of images for flatfield correction.
@@ -121,11 +114,15 @@ class Radiography(Experiment):
         self._finished = None
         self._flat_motor = flat_motor
         self._camera = camera
+        flat_motor_unit = self._flat_motor['position'].unit
+
         darks_acq = await Acquisition("darks", self._take_darks)
         flats_acq = await Acquisition("flats", self._take_flats)
         radios_acq = await Acquisition("radios", self._take_radios)
         await super().__ainit__([darks_acq, flats_acq, radios_acq], walker,
                                 separate_scans=separate_scans)
+        self.install_parameters({"flat_position": Quantity(flat_motor_unit),
+                                 "radio_position": Quantity(flat_motor_unit)})
 
     async def prepare(self):
         if await self._camera.get_state() != "standby":
@@ -316,15 +313,14 @@ class Tomography(Radiography):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: RotationMotor for tomography.
         :type tomography_motor: concert.devices.motors.base.RotationMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param num_flats: Number of images for flatfield correction.
@@ -401,30 +397,15 @@ class SteppedTomography(Tomography):
                         flat_position, camera, num_flats=200, num_darks=200,
                         num_projections=3000, angular_range=180 * q.deg,
                         start_angle=0 * q.deg, separate_scans=True):
-        await super().__ainit__(
-            walker=walker, flat_motor=flat_motor,
-            tomography_motor=tomography_motor,
-            radio_position=radio_position,
-            flat_position=flat_position,
-            camera=camera, num_flats=num_flats,
-            num_darks=num_darks,
-            num_projections=num_projections,
-            angular_range=angular_range,
-            start_angle=start_angle,
-            separate_scans=separate_scans
-        )
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
-        :param tomography_motor: RotationMotor for tomography scan.
-        :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type radio_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.camera.base.Camera
         :param num_flats: Number of images for flatfield correction.
@@ -438,6 +419,18 @@ class SteppedTomography(Tomography):
         :param start_angle: Start position of *tomography_motor* for the first projection.
         :type start_angle: q.deg
         """
+        await super().__ainit__(
+            walker=walker, flat_motor=flat_motor,
+            tomography_motor=tomography_motor,
+            radio_position=radio_position,
+            flat_position=flat_position,
+            camera=camera, num_flats=num_flats,
+            num_darks=num_darks,
+            num_projections=num_projections,
+            angular_range=angular_range,
+            start_angle=start_angle,
+            separate_scans=separate_scans
+        )
 
     async def _take_radios(self):
         """
@@ -480,15 +473,12 @@ class ContinuousTomography(Tomography):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
-        :param tomography_motor: ContinuousRotationMotor for tomography scan.
-        :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.camera.base.Camera
         :param num_flats: Number of images for flatfield correction.
@@ -637,17 +627,16 @@ class SteppedSpiralTomography(SteppedTomography, SpiralMixin):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: RotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.RotationMotor
         :param vertical_motor: LinearMotor to translate the sample along the tomographic axis.
         :type vertical_motor: concert.devices.motors.base.LinearMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param start_position_vertical: Start position of *vertical_motor*.
@@ -759,18 +748,17 @@ class ContinuousSpiralTomography(ContinuousTomography, SpiralMixin):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: ContinuousRotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
         :param vertical_motor: ContinuousLinearMotor to translate the sample along the tomographic
             axis.
         :type vertical_motor: concert.devices.motors.base.ContinuousLinearMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param start_position_vertical: Start position of *vertical_motor*.
@@ -975,14 +963,14 @@ class GratingInterferometryStepping(GratingInterferometryMixin, Radiography):
         :type walker: concert.storage.DirectoryWalker
         :param camera: Camera to acquire the images
         :type camera: concert.devices.cameras.base.Camera
-        :param flat_motor: Motor for moving the sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param stepping_motor:
         :type stepping_motor: concert.devices.motors.base.LinearMotor
-        :param flat_position: Position of flat_motor where the sample is not in the beam.
-        :type flat_position: q.mm
-        :param radio_position: Position of flat_motor where the sample is located in the beam.
-        :type radio_position: q.mm
+        :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
+            Unit must be the same as flat_motor['position'].
+        :param flat_position: Position of *flat_motor* that the sample is positioned out of the
+            beam. Unit must be the same as flat_motor['position'].
         :param grating_period: Periodicity of the stepped grating.
         :type grating_period: q.um
         :param num_darks: Number of dark images that are acquired.

--- a/concert/experiments/imaging.py
+++ b/concert/experiments/imaging.py
@@ -78,13 +78,13 @@ class Radiography(Experiment):
     well as the projections with the sample in the beam.
     """
 
-    num_flats = Parameter()
+    num_flats = Parameter(check=check(source=['standby', 'error']))
     """Number of images acquired for flatfield correction."""
 
-    num_darks = Parameter()
+    num_darks = Parameter(check=check(source=['standby', 'error']))
     """Number of images acquired for dark correction."""
 
-    num_projections = Parameter()
+    num_projections = Parameter(check=check(source=['standby', 'error']))
     """Number of projection images."""
 
     async def __ainit__(self, walker, flat_motor, radio_position, flat_position, camera, num_flats,
@@ -122,8 +122,9 @@ class Radiography(Experiment):
         radios_acq = await Acquisition("radios", self._take_radios)
         await super().__ainit__([darks_acq, flats_acq, radios_acq], walker,
                                 separate_scans=separate_scans)
-        self.install_parameters({"flat_position": Quantity(flat_motor_unit),
-                                 "radio_position": Quantity(flat_motor_unit)})
+        self.install_parameters(
+            {"flat_position": Quantity(flat_motor_unit, check=check(source=['standby', 'error'])),
+             "radio_position": Quantity(flat_motor_unit, check=check(source=['standby', 'error']))})
         await self.set_radio_position(radio_position)
         await self.set_flat_position(flat_position)
         await self.set_num_flats(num_flats)
@@ -307,10 +308,10 @@ class Tomography(Radiography):
        Abstract implementation of a tomography experiment.
        """
 
-    angular_range = Quantity(q.deg)
+    angular_range = Quantity(q.deg, check=check(source=['standby', 'error']))
     """Range for scanning the *tomography_motor*."""
 
-    start_angle = Quantity(q.deg)
+    start_angle = Quantity(q.deg, check=check(source=['standby', 'error']))
     """Initial position of the *tomography_motor*."""
 
     async def __ainit__(self, walker, flat_motor, tomography_motor, radio_position,
@@ -565,13 +566,13 @@ class SpiralMixin(Parameterizable):
     """
     Mixin for spiral tomography.
     """
-    start_position_vertical = Quantity(q.mm)
+    start_position_vertical = Quantity(q.mm, check=check(source=['standby', 'error']))
     """Initial position of the vertical motor."""
 
-    vertical_shift_per_tomogram = Quantity(q.mm)
+    vertical_shift_per_tomogram = Quantity(q.mm, check=check(source=['standby', 'error']))
     """Vertical shift per tomogram."""
 
-    sample_height = Quantity(q.mm)
+    sample_height = Quantity(q.mm, check=check(source=['standby', 'error']))
     """Height of the sample. *vertical_motor* will be scanned from *start_position_vertical* to
     *sample_height* + *vertical_shift_per_tomogram* to sample the whole specimen.
     """
@@ -876,19 +877,19 @@ class GratingInterferometryMixin(Parameterizable):
     Mixin for grating interferometry specific experiments.
     """
 
-    grating_period = Quantity(q.um)
+    grating_period = Quantity(q.um, check=check(source=['standby', 'error']))
     """Period of the grating to scan."""
 
-    num_periods = Parameter()
+    num_periods = Parameter(check=check(source=['standby', 'error']))
     """Number of gratings period so scan."""
 
-    num_steps_per_period = Parameter()
+    num_steps_per_period = Parameter(check=check(source=['standby', 'error']))
     """Number of stepping positions per grating period."""
 
-    stepping_start_position = Quantity(q.um)
+    stepping_start_position = Quantity(q.um, check=check(source=['standby', 'error']))
     """Position of the first grating step of *stepping_motor*"""
 
-    propagation_distance = Quantity(q.mm)
+    propagation_distance = Quantity(q.mm, check=check(source=['standby', 'error']))
     """
     Distance between the sample and the analyzer grating.
 

--- a/concert/experiments/imaging.py
+++ b/concert/experiments/imaging.py
@@ -762,7 +762,7 @@ class ContinuousSpiralTomography(ContinuousTomography, SpiralMixin):
         :param flat_motor: LinearMotor for moving sample in and out of the beam.
         :type flat_motor: concert.devices.motors.base.LinearMotor
         :param tomography_motor: ContinuousRotationMotor for tomography scan.
-        :type tomography_motor: concert.devices.motors.base.ContinuousLinearMotor
+        :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
         :param vertical_motor: ContinuousLinearMotor to translate the sample along the tomographic
             axis.
         :type vertical_motor: concert.devices.motors.base.ContinuousLinearMotor

--- a/concert/experiments/synchrotron.py
+++ b/concert/experiments/synchrotron.py
@@ -48,13 +48,12 @@ class Radiography(SynchrotronMixin, BaseRadiography):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param shutter: Stutter
@@ -89,15 +88,14 @@ class SteppedTomography(SynchrotronMixin, BaseSteppedTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: RotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.RotationMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type radio_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.camera.base.Camera
         :param shutter: Stutter
@@ -140,15 +138,14 @@ class ContinuousTomography(SynchrotronMixin, BaseContTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: ContinuousRotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.camera.base.Camera
         :param shutter: Stutter
@@ -193,18 +190,17 @@ class ContinuousSpiralTomography(SynchrotronMixin, BaseContSpiralTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: ContinuousRotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
         :param vertical_motor: ContinuousLinearMotor to translate the sample along the tomographic
             axis.
         :type vertical_motor: concert.devices.motors.base.ContinuousLinearMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param shutter: Stutter
@@ -260,17 +256,16 @@ class SteppedSpiralTomography(SynchrotronMixin, BaseSteppedSpiralTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: RotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.RotationMotor
         :param vertical_motor: LinearMotor to translate the sample along the tomographic axis.
         :type vertical_motor: concert.devices.motors.base.LinearMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param shutter: Stutter
@@ -325,14 +320,14 @@ class GratingInterferometryStepping(SynchrotronMixin, BasePhaseStepping):
         :type camera: concert.devices.cameras.base.Camera
         :param shutter: Shutter
         :type shutter: concert.devices.shutters.base.Shutter
-        :param flat_motor: Motor for moving the sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param stepping_motor:
         :type stepping_motor: concert.devices.motors.base.LinearMotor
-        :param flat_position: Position of flat_motor where the sample is not in the beam.
-        :type flat_position: q.mm
-        :param radio_position: Position of flat_motor where the sample is located in the beam.
-        :type radio_position: q.mm
+        :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
+            Unit must be the same as flat_motor['position'].
+        :param flat_position: Position of *flat_motor* that the sample is positioned out of the
+            beam. Unit must be the same as flat_motor['position'].
         :param grating_period: Periodicity of the stepped grating.
         :type grating_period: q.um
         :param num_darks: Number of dark images that are acquired.

--- a/concert/experiments/xraytube.py
+++ b/concert/experiments/xraytube.py
@@ -51,13 +51,12 @@ class Radiography(XrayTubeMixin, BaseRadiography):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param xray_tube: X-ray tube
@@ -92,15 +91,14 @@ class SteppedTomography(XrayTubeMixin, BaseSteppedTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: RotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.RotationMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type radio_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.camera.base.Camera
         :param xray_tube: X-ray tube
@@ -143,15 +141,14 @@ class ContinuousTomography(XrayTubeMixin, BaseContTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: ContinuousRotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.camera.base.Camera
         :param xray_tube: X-ray tube
@@ -196,18 +193,17 @@ class ContinuousSpiralTomography(XrayTubeMixin, BaseContSpiralTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: ContinuousRotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.ContinuousRotationMotor
         :param vertical_motor: ContinuousLinearMotor to translate the sample along the tomographic
            axis.
         :type vertical_motor: concert.devices.motors.base.ContinuousLinearMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-           beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param xray_tube: X-ray tube
@@ -263,17 +259,16 @@ class SteppedSpiralTomography(XrayTubeMixin, BaseSteppedSpiralTomo):
         """
         :param walker: Walker for storing experiment data.
         :type walker: concert.storage.Walker
-        :param flat_motor: LinearMotor for moving sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param tomography_motor: RotationMotor for tomography scan.
         :type tomography_motor: concert.devices.motors.base.RotationMotor
         :param vertical_motor: LinearMotor to translate the sample along the tomographic axis.
         :type vertical_motor: concert.devices.motors.base.LinearMotor
         :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
-        :type radio_position: q.mm
+            Unit must be the same as flat_motor['position'].
         :param flat_position: Position of *flat_motor* that the sample is positioned out of the
-            beam.
-        :type flat_position: q.mm
+            beam. Unit must be the same as flat_motor['position'].
         :param camera: Camera to acquire the images.
         :type camera: concert.devices.cameras.base.Camera
         :param xray_tube: X-ray tube
@@ -329,14 +324,14 @@ class GratingInterferometryStepping(XrayTubeMixin, BasePhaseStepping):
         :type camera: concert.devices.cameras.base.Camera
         :param xray_tube: Xray tube
         :type xray_tube: concert.devices.xraytubes.base.XRayTube
-        :param flat_motor: Motor for moving the sample in and out of the beam.
-        :type flat_motor: concert.devices.motors.base.LinearMotor
+        :param flat_motor: Motor for moving sample in and out of the beam. Must feature a
+            'position' property.
         :param stepping_motor:
         :type stepping_motor: concert.devices.motors.base.LinearMotor
-        :param flat_position: Position of flat_motor where the sample is not in the beam.
-        :type flat_position: q.mm
-        :param radio_position: Position of flat_motor where the sample is located in the beam.
-        :type radio_position: q.mm
+        :param radio_position: Position of *flat_motor* that the sample is positioned in the beam.
+            Unit must be the same as flat_motor['position'].
+        :param flat_position: Position of *flat_motor* that the sample is positioned out of the
+            beam. Unit must be the same as flat_motor['position'].
         :param grating_period: Periodicity of the stepped grating.
         :type grating_period: q.um
         :param num_darks: Number of dark images that are acquired.


### PR DESCRIPTION
TODO:

- [x] Docs
- [x] Discuss if something more elegant can be done instead of the LaminographyMixin

In `concert.experiments.imaging.Radiography` the `flat_position` and `radio_position` `Quantity` is created with the unit of the `flatfield_motor['position']` property. This allows to use `LinearMotor`s and `RotationMotor`s