### PR TITLE
concert: enable nesting await imports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ omit =
     concert/devices/cameras/pco.py
     concert/ext/*.py
     concert/processes/ufo.py
+    concert/tests/util/_*.py
     */python?.?/*
     */lib-python/?.?/*.py
     */site-packages/*

--- a/bin/concert
+++ b/bin/concert
@@ -4,8 +4,6 @@ import ast
 import asyncio
 import argparse
 import contextlib
-import importlib
-import inspect
 import logging
 import os
 import re
@@ -18,68 +16,11 @@ import zipfile
 import concert
 import concert.config
 import concert.session.management as cs
+from concert._aimport import AsyncMetaPathFinder, eval_nodes
 from concert.ext.cmd import plugins
 
 
 LOG = logging.getLogger(__name__)
-
-
-# Start of enabling importing python files with "await" outside of "async def" functions
-
-
-class AsyncLoader(importlib.machinery.SourceFileLoader):
-    """
-    Normal SourceFileLoader with the capability of dealing with `await' outside of `async def'
-    functions. The trick is the flag ast.PyCF_ALLOW_TOP_LEVEL_AWAIT and eval() instead of exec()
-    used by Python's :class:`_LoaderBasics` class.
-
-    If the module has `await' outside of a function, eval() will return a coroutine which we execute
-    in the session's loop, that is why sys.meta_path must be updated *after* the loop has been
-    created (to make sure it's the one IPython also uses).
-    """
-    def exec_module(self, module):
-        cobj = compile(
-            self.get_data(self.path),
-            self.path,
-            'exec',
-            dont_inherit=True,
-            flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
-        )
-        result = eval(cobj, module.__dict__)
-        if inspect.iscoroutine(result):
-            loop = asyncio.get_event_loop()
-            try:
-                loop.run_until_complete(result)
-            except RuntimeError as err:
-                raise StartError(
-                    f"Module `{module.__name__}' uses `await' outside of `async def' "
-                    "functions but at the same time tries to execute coroutines in a loop "
-                    "which is not allowed, please remove the loop-running code from the module "
-                    "and try again"
-                ) from err
-
-
-class AsyncMetaPathFinder(importlib.abc.MetaPathFinder):
-    """
-    MetaPathFinder implementation which used :class;`.FileFinder` for dealing with paths and
-    instantiated with our AsyncLoader for the handling of `await' outside of `async def' functions.
-    """
-    def find_spec(self, fullname, path, target=None):
-        if path is None:
-            path = sys.path
-
-        for entry in path:
-            finder = importlib.machinery.FileFinder(entry, (AsyncLoader, ('.py',)))
-            spec = finder.find_spec(fullname, target=target)
-            if spec:
-                return spec
-
-
-class StartError(Exception):
-    """Startup errors."""
-
-
-# End of enabling importing python files with "await" outside of "async def" functions
 
 
 def docstring_summary(doc):
@@ -460,35 +401,17 @@ class StartCommand(SubCommand):
 
         # Add session path, so that sessions can import other sessions
         sys.path.append(cs.path())
+        path = filename or cs.path(session)
 
         if non_interactive:
-
-            if session:
-                code_obj = compile(
-                    open(cs.path(session), "rb").read(),
-                    cs.path(session),
-                    'exec',
-                    flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
-                )
-                eval_result = eval(code_obj, globals())
-                if inspect.iscoroutine(eval_result):
-                    loop = asyncio.get_event_loop()
-                    # More-or less a copy of asyncio.run() but with our loop
-                    try:
-                        loop.run_until_complete(eval_result)
-                    finally:
-                        to_cancel = asyncio.all_tasks(loop=loop)
-                        for task in to_cancel:
-                            task.cancel()
-                        loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
-                        loop.run_until_complete(loop.shutdown_asyncgens())
-                        if hasattr(loop, 'shutdown_default_executor'):
-                            # Only in Python 3.9+
-                            loop.run_until_complete(loop.shutdown_default_executor())
+            with open(path, "rb") as f:
+                source = f.read()
+            nodes = ast.parse(source).body
+            eval_nodes(nodes, {}, filename=path)
         else:
-            self.run_shell(path=filename or cs.path(session) if session else None)
+            self.run_shell(path=path, session=session)
 
-    def run_shell(self, path=None):
+    def run_shell(self, path=None, session=None):
         import IPython
         import traitlets.config
         from concert.session.utils import abort_awaiting
@@ -512,19 +435,26 @@ class StartCommand(SubCommand):
 
         print("Welcome to Concert {0}".format(concert.__version__))
 
-        if path:
+        ip_config = traitlets.config.Config()
+        if path and path.endswith('.py'):
             with open(path) as session_file:
                 session_code = session_file.read()
             tree = ast.parse(session_code)
             docstring = ast.get_docstring(tree)
             if docstring:
                 print(docstring)
+
+            if session is None:
+                # --filename must have been specified
+                session = os.path.splitext(os.path.basename(path))[0]
+                sys.path.append(os.path.dirname(path))
+
+            ip_config.InteractiveShellApp.exec_lines = [f'from {session} import *']
         else:
             session_code = 'from concert.quantities import q'
+            ip_config.InteractiveShellApp.exec_lines = [session_code]
 
-        ip_config = traitlets.config.Config()
         ip_config.InteractiveShellApp.gui = 'asyncio'
-        ip_config.InteractiveShellApp.exec_lines = [session_code]
         # This is the most robust way when taking virtualenv into account I have found so far
         ip_config.InteractiveShellApp.exec_files = [os.path.join(concert.__path__[0],
                                                                  '_ipython_setup.py')]

--- a/concert/_aimport.py
+++ b/concert/_aimport.py
@@ -1,0 +1,148 @@
+"""Internal module for the support of imports with top-level `await' (outside of `async def'
+functions).
+"""
+import ast
+import asyncio
+import importlib
+import inspect
+import logging
+import os
+import sys
+import threading
+import concert.session.management as cs
+from concert.config import AIODEBUG
+
+
+LOG = logging.getLogger(__name__)
+SESSION_PATH = cs.path()
+
+
+class AsyncLoader(importlib.machinery.SourceFileLoader):
+    """
+    Normal SourceFileLoader with the capability of dealing with `await' outside of `async def'
+    functions. The trick is the flag ast.PyCF_ALLOW_TOP_LEVEL_AWAIT and eval() instead of exec()
+    used by Python's :class:`_LoaderBasics` class.
+
+    If the module has `await' outside of a function, eval() will return a coroutine which we execute
+    in the session's loop, that is why sys.meta_path must be updated *after* the loop has been
+    created (to make sure it's the one IPython also uses).
+    """
+    def exec_module(self, module):
+        """
+        Execute *module* step-wise and allow *await* on the module level and module nesting with
+        top-level `await'.
+        """
+        # *nodes* are all ast nodes of the module
+        nodes = ast.parse(self.get_data(self.path)).body
+        eval_nodes(nodes, module.__dict__, filename=self.path)
+
+
+class AsyncMetaPathFinder(importlib.abc.MetaPathFinder):
+    """
+    MetaPathFinder implementation which used :class;`.FileFinder` for dealing with paths and
+    instantiated with our AsyncLoader for the handling of `await' outside of `async def' functions.
+    """
+    def find_spec(self, fullname, path, target=None):
+
+        if path is None:
+            # If this is a top-level import *path* is None, otherwise do not mess with it and use
+            # the one provided by the package hierarchy.
+            # If it is None, make sure user modules are found before system modules, e.g. when
+            # someone decides to name a session `test', which exists in pythonX.Y/test/__init__.py
+            path = [SESSION_PATH, os.getcwd()] + sys.path
+
+        for entry in path:
+            finder = importlib.machinery.FileFinder(entry, (AsyncLoader, ('.py',)))
+            spec = finder.find_spec(fullname, target=target)
+            if spec:
+                return spec
+
+
+def eval_nodes(nodes, module_dict, filename=''):
+    """
+    Source code in ast *nodes* is split into import and non-import statements. All import statements
+    are executed one-by-one and all other statements are aggregated and executed together. This way
+    we allow nesting of module imports which have top-level `await' keywords. This is possible
+    thanks to the fact that when we call :func:`eval` on an import statement, it will not return a
+    coroutine but it will invoke the import mechanism (thus us) on the module to be imported.  Then
+    that nested module is processed with the loop run if necessary and stopped. Then the recursion
+    ends and the importing module processes the rest of the statements with possible loop runs which
+    is fine becuase the nested module is processed already, so no nested loop runs are attempted.
+    """
+    def _is_import(node):
+        return isinstance(node, ast.Import) or isinstance(node, ast.ImportFrom)
+
+    def _eval_submodule(start, stop):
+        # Make an empty tree and fill it with a portion of *nodes* from the *module* tree
+        submodule = ast.parse('')
+        submodule.body = nodes[start:stop]
+        cobj = compile(
+            submodule,
+            f'{filename or "<string>"}',
+            'exec',
+            dont_inherit=True,
+            flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+        )
+
+        result = eval(cobj, module_dict)
+
+        if inspect.iscoroutine(result):
+            try:
+                loop = asyncio.get_event_loop_policy().get_event_loop()
+            except RuntimeError as err:
+                if threading.current_thread() is not threading.main_thread():
+                    # If we are in a different thread we create the loop if not existing
+                    # (RuntimeError raised).
+                    loop = asyncio.get_event_loop_policy().new_event_loop()
+                else:
+                    raise err
+
+            try:
+                LOG.log(
+                    AIODEBUG,
+                    'import running in loop for %s, nodes %d-%d',
+                    filename or '<string>',
+                    start,
+                    stop
+                )
+                loop.run_until_complete(result)
+            except RuntimeError as err:
+                # Actually, if we ever need this we can split the execution even on a finer level
+                # and allow mixing `await' and `run_in_loop' (by executing those lines separately)
+                name = os.path.basename(os.path.splitext(filename)[0])
+                raise ImportError(
+                    f"Error loading module `{name}'.\n"
+                    # 1
+                    f"Possible cause 1: `{name}' uses top-level `await' (i.e. outside of `async "
+                    "def' functions) but at the same time tries to execute coroutines in a loop "
+                    "at the top level. "
+                    "To fix this, remove the loop-running code from the top level of the module "
+                    "which has a top-level `await'.\n"
+                    # 2
+                    f"Possible cause 2: `{name}' was tried to be imported from another module "
+                    "from within a running loop, e.g. from an `async def' function. "
+                    "To fix this, put all imports to the top level (outside of functions).",
+                    path=filename,
+                    name=name
+                ) from err
+
+    # Do not execute statement-by-statement but aggregate non-import statements for performance
+    start = stop = -1
+    for i, node in enumerate(nodes):
+        if _is_import(node):
+            if stop > start:
+                # There were non-import statements before us
+                _eval_submodule(start, stop)
+            # Evaluate us (the import statement) and reset indices
+            _eval_submodule(i, i + 1)
+            start = stop = -1
+        else:
+            if start == -1:
+                # Initialize *start* if we just started or were on an import statement
+                start = i
+            # count the lines which can be aggregated (non-import) (open interval)
+            stop = i + 1
+
+    if stop > start:
+        # Leftover code after last import statement
+        _eval_submodule(start, stop)

--- a/concert/_aimport.py
+++ b/concert/_aimport.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import concert.session.management as cs
 from concert.config import AIODEBUG
+from concert.coroutines.base import get_event_loop
 
 
 LOG = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ def eval_nodes(nodes, module_dict, filename=''):
 
         if inspect.iscoroutine(result):
             try:
-                loop = asyncio.get_event_loop_policy().get_event_loop()
+                loop = get_event_loop()
             except RuntimeError as err:
                 if threading.current_thread() is not threading.main_thread():
                     # If we are in a different thread we create the loop if not existing

--- a/concert/base.py
+++ b/concert/base.py
@@ -7,7 +7,7 @@ import functools
 import inspect
 import types
 from concert.helpers import memoize
-from concert.coroutines.base import background, run_in_loop, wait_until
+from concert.coroutines.base import background, get_event_loop, run_in_loop, wait_until
 from concert.quantities import q
 
 
@@ -563,7 +563,7 @@ class ParameterValue(object):
         return self._parameter.name < other._parameter.name
 
     def __repr__(self):
-        if asyncio.get_event_loop().is_running():
+        if get_event_loop().is_running():
             return repr(self._parameter)
         else:
             return run_in_loop(self.info_table).get_string()
@@ -1196,13 +1196,13 @@ class Parameterizable(AsyncObject):
                     self._install_parameter(attr_type)
 
     def __str__(self):
-        if asyncio.get_event_loop().is_running():
+        if get_event_loop().is_running():
             return super().__str__()
         else:
             return run_in_loop(self.info_table).get_string(sortby="Parameter")
 
     def __repr__(self):
-        if asyncio.get_event_loop().is_running():
+        if get_event_loop().is_running():
             return super().__repr__()
         else:
             return '\n'.join([super(Parameterizable, self).__repr__(), str(self)])

--- a/concert/coroutines/base.py
+++ b/concert/coroutines/base.py
@@ -17,13 +17,18 @@ async def async_generate(iterable):
         yield item
 
 
+def get_event_loop():
+    """Get asyncio's event loop."""
+    return asyncio.get_event_loop_policy().get_event_loop()
+
+
 def run_in_loop(coroutine, error_msg_if_running=None):
     """Wrap *coroutine* into a `asyncio.Task`, run it in the current loop, block until it finishes
     and return the result. On KeyboardInterrupt, the task is cancelled. Raise RuntimeError with
     message *error_msg_if_running* in case the loop is already running, otherwise Python will take
     care of the error reporting.
     """
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     if error_msg_if_running and loop.is_running():
         raise RuntimeError(error_msg_if_running)
     task = asyncio.ensure_future(coroutine, loop=loop)
@@ -55,7 +60,7 @@ def run_in_executor(func, *args):
     #         LOG.log(AIODEBUG, f'{func.__name__} waiting for concurrent.Future')
     #         return await future
     # return make_coro()
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
 
     return loop.run_in_executor(None, func, *args)
 
@@ -92,7 +97,7 @@ def broadcast(producer, *consumers):
 
     Feed *producer* to all *consumers*.
     """
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     next_val = loop.create_future()
     consumed = loop.create_future()
     stop = object()

--- a/concert/session/utils.py
+++ b/concert/session/utils.py
@@ -6,7 +6,7 @@ import inspect
 import subprocess
 import prettytable
 from concert.config import AIODEBUG
-from concert.coroutines.base import background, run_in_loop
+from concert.coroutines.base import background, get_event_loop, run_in_loop
 from concert.devices.base import Device
 from concert.quantities import q
 
@@ -164,7 +164,7 @@ def abort_awaiting(background=False, skip=None):
         # _coro instead of get_coro() for Python 3.7 compatibility
         return os.path.dirname(task._coro.cr_code.co_filename)
 
-    loop = asyncio.get_event_loop()
+    loop = get_event_loop()
     try:
         LOG.debug('Global abort called, loop: %d, IPython loop: %d', id(loop),
                   id(get_ipython().pt_loop))

--- a/concert/tests/unit/test_aimport.py
+++ b/concert/tests/unit/test_aimport.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import warnings
+from concert._aimport import AsyncMetaPathFinder
+from concert.tests import TestCase
+
+
+class TestAImport(TestCase):
+    def setUp(self):
+        self.import_path = os.path.join(os.getcwd(), 'concert', 'tests', 'util')
+        self.async_path_finder = AsyncMetaPathFinder()
+        sys.meta_path.insert(0, self.async_path_finder)
+        sys.path.insert(0, self.import_path)
+
+    def tearDown(self):
+        # Do not rely on the index in setUp
+        sys.path.remove(self.import_path)
+        sys.meta_path.remove(self.async_path_finder)
+
+    def test_nested_aimport(self):
+        self._check_values()
+
+    def test_import_in_thread(self):
+        import threading
+
+        def import_in_thread():
+            self._check_values()
+
+        t = threading.Thread(target=import_in_thread)
+        t.start()
+        t.join()
+
+    async def test_mixed_loop_await(self):
+        with warnings.catch_warnings():
+            # Otherwise we'd get "RuntimeWarning: coroutine 'sleep' was never awaited"
+            # Also, the test needs to be `async def' for the warning to be suppressed
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            with self.assertRaises(ImportError):
+                import _mixed_loop_await_session
+                # Prevent flake8 F401: imported but unused
+                _mixed_loop_await_session
+
+    def test_aimport_in_async_func(self):
+        with warnings.catch_warnings():
+            # Otherwise we'd get "RuntimeWarning: coroutine 'sleep' was never awaited"
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            with self.assertRaises(ImportError):
+                import _aimport_in_async_func_session
+                # Prevent flake8 F401: imported but unused
+                _aimport_in_async_func_session
+
+    def _check_values(self):
+        from _session import value, nested_value
+        self.assertEqual(value, 0)
+        self.assertEqual(nested_value, 0)

--- a/concert/tests/util/_aimport_in_async_func_session.py
+++ b/concert/tests/util/_aimport_in_async_func_session.py
@@ -1,0 +1,5 @@
+async def foo():
+    import _session
+
+
+await foo()

--- a/concert/tests/util/_mixed_loop_await_session.py
+++ b/concert/tests/util/_mixed_loop_await_session.py
@@ -1,0 +1,4 @@
+import asyncio
+
+await asyncio.sleep(0)
+asyncio.run(asyncio.sleep(0))

--- a/concert/tests/util/_nested_session.py
+++ b/concert/tests/util/_nested_session.py
@@ -1,0 +1,3 @@
+import asyncio
+
+nested_value = await asyncio.sleep(0, result=0)

--- a/concert/tests/util/_session.py
+++ b/concert/tests/util/_session.py
@@ -1,0 +1,4 @@
+import asyncio
+from _nested_session import nested_value
+
+value = await asyncio.sleep(0, result=0)

--- a/docs/user/topics/shell.rst
+++ b/docs/user/topics/shell.rst
@@ -247,7 +247,7 @@ The quantities package is already loaded and named ``q``.
 .. note::
 
     You may use the ``await`` keyword in session files and the sesion will be
-    loaded correctly.
+    loaded correctly, for details see Importing_.
 
 
 docs
@@ -269,6 +269,55 @@ session's docstring. The docstring should be formatted in Markdown markup.
 
 .. _Pandoc: http://pandoc.org/
 .. _PDFLaTeX: http://ctan.org/pkg/pdftex
+
+
+Importing
+=========
+
+When you import a module or a session, before anything else, concert first looks
+into the sessions directory. If the module is not found, it looks into the
+current working directory and if it is not found even there it searches in
+``sys.path``, where all the standard paths are stored.
+
+Concert can run sessions with top-level ``await`` (outside ``async def``
+functions). Sessions can also import such modules into them and even nest such
+imports. There are two limitations to this:
+
+- if you have a top-level ``await`` in a module, you cannot use the asyncio's
+  loop, e.g. by concert's ``run_in_loop`` function
+- you cannot import modules with top-level ``await`` inside functions, you need
+  to put the imports to the top level
+
+
+For example, this is possible (session ``motors``)::
+
+    from concert.devices.motors.dummy import LinearMotor
+
+    motor = await LinearMotor()
+
+
+and this is possible::
+
+    from motors import motor
+    from concert.quantities import q
+
+    await motor.set_position(1 * q.mm)
+
+
+On the other hand, this is *not* possible::
+
+    async def foo():
+        import motors  # The example session above
+
+    await foo()
+
+
+and this is *not* possible::
+
+    from concert.coroutines.base import run_in_loop
+    await asyncio.sleep(1)
+    run_in_loop(asyncio.sleep(1))
+
 
 
 Remote access

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,4 @@ deps = -r{toxinidir}/requirements.txt
 [flake8]
 max-line-length = 100
 ignore = F841, W503, W605
+exclude = concert/tests/util/_*.py


### PR DESCRIPTION
Improvement of #482 which allows to nest module imports which need to run async code in a loop.

@MarcusZuber go ahead and break it again ;-)

Some scenarios are known not to work but I think they are easily avoidable and we throw a pretty instructive `ImportError` in case these occur.

This won't work:
```python
# the `await' needs to run the import in a loop 
# and on the next line we try to run the loop as well, so, nesting
await asyncio.sleep(0)
loop.run_until_complete(asyncio.sleep(0))
```

And this won't work:
```python
# barmodule:
await asyncio.sleep(0)

# foomodule:
async def foo():
    import barmodule

# We need to be imported in a loop and try to import
# module which will need to run a loop, nesting again.
await foo()
```