### PR TITLE
Sets the ipython-session profile to "concert_*session_name*"

### DIFF
--- a/bin/concert
+++ b/bin/concert
@@ -406,6 +406,8 @@ class StartCommand(SubCommand):
         print("Welcome to Concert {0}".format(concert.__version__))
 
         ip_config = traitlets.config.Config()
+        if session is not None:
+            ip_config.BaseIPythonApplication.profile = f"concert_{session}"
         if path and path.endswith('.py'):
             lockdir = os.path.join(os.path.expanduser("~"), ".concert")
             os.makedirs(lockdir, mode=0o755, exist_ok=True)

--- a/bin/concert
+++ b/bin/concert
@@ -144,12 +144,12 @@ class LogCommand(SubCommand):
             cs.exit_if_not_exists(session)
 
             if follow:
-                cmd = 'tail -f {} | grep --line-buffered "{}:"'.format(logfile, session)
+                cmd = 'tail -F {} | grep --line-buffered "{}:"'.format(logfile, session)
             else:
                 cmd = 'grep "{0}:" {1} | less'.format(session, logfile)
         else:
             if follow:
-                cmd = 'tail -f {}'.format(logfile)
+                cmd = 'tail -F {}'.format(logfile)
             else:
                 cmd = 'less {}'.format(logfile)
 

--- a/bin/concert
+++ b/bin/concert
@@ -405,12 +405,18 @@ class StartCommand(SubCommand):
 
         print("Welcome to Concert {0}".format(concert.__version__))
 
+        filename_session = session is None and path and path.endswith('.py')
+        if filename_session:
+            session = os.path.splitext(os.path.basename(path))[0]
+
         ip_config = traitlets.config.Config()
+        if session is not None:
+            ip_config.BaseIPythonApplication.profile = f"concert_{session}"
         if path and path.endswith('.py'):
             lockdir = os.path.join(os.path.expanduser("~"), ".concert")
             os.makedirs(lockdir, mode=0o755, exist_ok=True)
             lockfile = os.path.join(lockdir, '.' + os.path.basename(path))
-            if not cs.is_multiinstance(session):
+            if not cs.is_multiinstance(path if filename_session else session):
                 if os.path.exists(lockfile):
                     print(f"An instance of `{session}' seems to be already running.")
                     print(
@@ -426,9 +432,8 @@ class StartCommand(SubCommand):
             if docstring:
                 print(docstring)
 
-            if session is None:
+            if filename_session:
                 # --filename must have been specified
-                session = os.path.splitext(os.path.basename(path))[0]
                 sys.path.append(os.path.dirname(path))
             ip_config.InteractiveShellApp.exec_lines = [STARTUP_FMT.format(session, lockfile)]
         else:

--- a/concert/session/management.py
+++ b/concert/session/management.py
@@ -6,6 +6,8 @@ import ast
 import os
 import sys
 import shutil
+from IPython.core.profiledir import ProfileDir, ProfileDirError
+from IPython.paths import get_ipython_dir
 
 _CACHED_PATH = None
 
@@ -87,9 +89,17 @@ def create(session, imports=()):
 
 
 def remove(session):
-    """Remove a *session*."""
+    """Remove a *session* and the corresponding profile directory."""
     if exists(session):
         os.unlink(path(session))
+        try:
+            profile_folder = ProfileDir.find_profile_dir_by_name(get_ipython_dir(),
+                                                                 f"concert_{session}")
+            shutil.rmtree(profile_folder.location)
+        except ProfileDirError as e:
+            # No profile directory found
+            # This can happen if the session was created with an older version or was never started
+            pass
 
 
 def move(source, target):

--- a/concert/session/management.py
+++ b/concert/session/management.py
@@ -6,6 +6,8 @@ import ast
 import os
 import sys
 import shutil
+from IPython.core.profiledir import ProfileDir, ProfileDirError
+from IPython.paths import get_ipython_dir
 
 _CACHED_PATH = None
 
@@ -87,9 +89,16 @@ def create(session, imports=()):
 
 
 def remove(session):
-    """Remove a *session*."""
+    """Remove a *session* and the corresponding profile directory."""
     if exists(session):
         os.unlink(path(session))
+    try:
+        profile_folder = ProfileDir.find_profile_dir_by_name(get_ipython_dir(),
+                                                             f"concert_{session}")
+        shutil.rmtree(profile_folder.location)
+    except ProfileDirError:
+        # This can happen if the session was created with an older version or was never started.
+        pass
 
 
 def move(source, target):

--- a/concert/session/utils.py
+++ b/concert/session/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from logging.handlers import TimedRotatingFileHandler
 import math
 import os
 import abc
@@ -50,7 +51,7 @@ def setup_logging(name, to_stream=False, filename=None, loglevel=None):
         stream_handler.setFormatter(formatter)
         logger.addHandler(stream_handler)
     if filename:
-        file_handler = logging.FileHandler(filename)
+        file_handler = logging.handlers.TimedRotatingFileHandler(filename, when="D", backupCount=0)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
 

--- a/concert/session/utils.py
+++ b/concert/session/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from logging.handlers import TimedRotatingFileHandler
 import math
 import os
 import abc
@@ -50,7 +51,7 @@ def setup_logging(name, to_stream=False, filename=None, loglevel=None):
         stream_handler.setFormatter(formatter)
         logger.addHandler(stream_handler)
     if filename:
-        file_handler = logging.FileHandler(filename)
+        file_handler = TimedRotatingFileHandler(filename, when='D', backupCount=0)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
 

--- a/concert/tests/unit/test_ipython_profiles.py
+++ b/concert/tests/unit/test_ipython_profiles.py
@@ -1,0 +1,107 @@
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from concert.tests import TestCase
+
+
+class TestIPythonProfiles(TestCase):
+    def test_system_command_creates_and_removes_profile(self):
+        concert_command = shutil.which('concert')
+        if concert_command is None:
+            self.skipTest('concert command is not installed')
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            env = os.environ.copy()
+            env.pop('VIRTUAL_ENV', None)
+            env['IPYTHONDIR'] = str(root / 'ipython')
+            env['XDG_DATA_HOME'] = str(root / 'data')
+
+            self._run_concert(env, 'init', 'system', executable=concert_command)
+            self._run_concert(
+                env,
+                'start',
+                'system',
+                input_text='system_marker = 1\nexit()\n',
+                executable=concert_command,
+            )
+
+            profile = root / 'ipython' / 'profile_concert_system'
+            self.assertTrue(profile.is_dir())
+            self.assertTrue((profile / 'history.sqlite').is_file())
+
+            self._run_concert(env, 'rm', 'system', executable=concert_command)
+            self.assertFalse(profile.exists())
+
+    def test_sessions_have_separate_histories_and_rm_removes_profiles(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            env = os.environ.copy()
+            env.pop('VIRTUAL_ENV', None)
+            env['IPYTHONDIR'] = str(root / 'ipython')
+            env['XDG_DATA_HOME'] = str(root / 'data')
+
+            for session in ('first', 'second'):
+                self._run_concert(env, 'init', session)
+
+            self._run_concert(env, 'start', 'first', input_text="first_marker = 1\nexit()\n")
+            self._run_concert(env, 'start', 'second', input_text="second_marker = 2\nexit()\n")
+
+            first_history = root / 'ipython' / 'profile_concert_first' / 'history.sqlite'
+            second_history = root / 'ipython' / 'profile_concert_second' / 'history.sqlite'
+            self.assertTrue(first_history.is_file())
+            self.assertTrue(second_history.is_file())
+            self.assertNotEqual(first_history, second_history)
+            self.assertIn('first_marker', self._history(first_history))
+            self.assertNotIn('second_marker', self._history(first_history))
+            self.assertIn('second_marker', self._history(second_history))
+            self.assertNotIn('first_marker', self._history(second_history))
+
+            self._run_concert(env, 'rm', 'first')
+            self.assertFalse(first_history.parent.exists())
+            self.assertTrue(second_history.parent.exists())
+
+    def test_filename_session_uses_its_own_profile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            session_file = root / 'external_session.py'
+            session_file.write_text('external_marker = 1\n')
+            env = os.environ.copy()
+            env.pop('VIRTUAL_ENV', None)
+            env['IPYTHONDIR'] = str(root / 'ipython')
+            env['XDG_DATA_HOME'] = str(root / 'data')
+
+            self._run_concert(env, 'start', '--filename', str(session_file),
+                              input_text="exit()\n")
+
+            history = root / 'ipython' / 'profile_concert_external_session' / 'history.sqlite'
+            self.assertTrue(history.is_file())
+
+    @staticmethod
+    def _run_concert(env, *arguments, input_text=None, executable=None):
+        command = executable or sys.executable
+        prefix = [command] if executable else [command, 'bin/concert']
+        result = subprocess.run(
+            [*prefix, *arguments],
+            env=env,
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode:
+            raise AssertionError(
+                f"concert {' '.join(arguments)} failed:\n{result.stdout}\n{result.stderr}"
+            )
+        return result
+
+    @staticmethod
+    def _history(filename):
+        with sqlite3.connect(filename) as database:
+            return '\n'.join(row[0] for row in database.execute('SELECT source FROM history'))

--- a/concert/tests/unit/test_logging.py
+++ b/concert/tests/unit/test_logging.py
@@ -1,0 +1,83 @@
+import logging
+import os
+import runpy
+import tempfile
+from logging.handlers import TimedRotatingFileHandler
+from unittest.mock import patch
+
+from concert.session.utils import setup_logging
+from concert.tests import TestCase
+
+
+class TestLogging(TestCase):
+    def setUp(self):
+        super().setUp()
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self):
+        super().tearDown()
+        root_logger = logging.getLogger()
+        for handler in getattr(self, '_logging_handlers', []):
+            handler.close()
+            root_logger.removeHandler(handler)
+
+    def test_setup_logging_writes_to_a_daily_rotating_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logfile = os.path.join(tmpdir, 'concert.log')
+
+            setup_logging('test-session', filename=logfile, loglevel='info')
+            handlers = [handler for handler in logging.getLogger().handlers
+                        if isinstance(handler, TimedRotatingFileHandler)]
+            self._logging_handlers = handlers
+
+            self.assertEqual(len(handlers), 1)
+            self.assertEqual(handlers[0].when, 'D')
+            self.assertEqual(handlers[0].backupCount, 0)
+
+            logging.getLogger('test.logger').info('message')
+            handlers[0].flush()
+
+            with open(logfile) as log:
+                content = log.read()
+            self.assertIn('test-session', content)
+            self.assertIn('message', content)
+
+    def test_daily_rotation_keeps_the_new_log_at_the_base_filename(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logfile = os.path.join(tmpdir, 'concert.log')
+            setup_logging('test-session', filename=logfile, loglevel='info')
+            handler = next(handler for handler in logging.getLogger().handlers
+                           if isinstance(handler, TimedRotatingFileHandler))
+            self._logging_handlers = [handler]
+            logging.getLogger('test.logger').info('before rotation')
+            handler.flush()
+
+            rotated = logfile + '.2026-08-05'
+            with patch.object(handler, 'rotation_filename', return_value=rotated), \
+                    patch('logging.handlers.time.time', return_value=handler.rolloverAt + 1):
+                handler.doRollover()
+
+            logging.getLogger('test.logger').info('after rotation')
+            handler.flush()
+
+            with open(rotated) as log:
+                self.assertIn('before rotation', log.read())
+            with open(logfile) as log:
+                self.assertIn('after rotation', log.read())
+
+    def test_log_follow_uses_f_for_rotating_logfiles(self):
+        namespace = runpy.run_path(
+            os.path.join(os.path.dirname(__file__), '..', '..', '..', 'bin', 'concert'),
+            run_name='concert_cli',
+        )
+        log_command = namespace['LogCommand']()
+        with patch.object(namespace['cs'], 'logfile_path', return_value='/tmp/concert.log'), \
+                patch.object(namespace['cs'], 'exit_if_not_exists'), \
+                patch.object(namespace['os'].path, 'exists', return_value=True), \
+                patch.object(namespace['subprocess'], 'call') as call:
+            log_command.run(session='session', follow=True)
+
+        call.assert_called_once_with(
+            'tail -F /tmp/concert.log | grep --line-buffered "session:"',
+            shell=True,
+        )

--- a/concert/tests/unit/test_session_management.py
+++ b/concert/tests/unit/test_session_management.py
@@ -1,4 +1,7 @@
 import os
+import tempfile
+from unittest.mock import patch
+
 import concert.session.management as cs
 from concert.tests import TestCase
 
@@ -13,3 +16,39 @@ class TestSessionManagement(TestCase):
             '_aimport_future_imports.py'
         )
         self.assertEqual(cs.get_docstring(filename), 'docstring')
+
+    def test_remove_deletes_session_and_profile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_path = os.path.join(tmpdir, 'session.py')
+            profile_path = os.path.join(tmpdir, 'profile_concert_session')
+            os.mkdir(profile_path)
+            open(session_path, 'w').close()
+
+            with patch.object(cs, '_CACHED_PATH', tmpdir), \
+                    patch.object(cs, 'get_ipython_dir', return_value=tmpdir):
+                cs.remove('session')
+
+            self.assertFalse(os.path.exists(session_path))
+            self.assertFalse(os.path.exists(profile_path))
+
+    def test_remove_without_profile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_path = os.path.join(tmpdir, 'session.py')
+            open(session_path, 'w').close()
+
+            with patch.object(cs, '_CACHED_PATH', tmpdir), \
+                    patch.object(cs, 'get_ipython_dir', return_value=tmpdir):
+                cs.remove('session')
+
+            self.assertFalse(os.path.exists(session_path))
+
+    def test_remove_deletes_orphaned_profile(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            profile_path = os.path.join(tmpdir, 'profile_concert_session')
+            os.mkdir(profile_path)
+
+            with patch.object(cs, '_CACHED_PATH', tmpdir), \
+                    patch.object(cs, 'get_ipython_dir', return_value=tmpdir):
+                cs.remove('session')
+
+            self.assertFalse(os.path.exists(profile_path))


### PR DESCRIPTION
This creates and uses independent ipython session profiles for each concert session.
This helps to separates histories between sessions.

TODOs:

- [x]  Delete profile folders together with the sessions
- [x] Test profile creation
- [x] Test profile deletion
- [x] Change concert.log to a rotating format
