### PR TITLE
do not fail test if codecov fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,5 +39,5 @@ jobs:
       if: matrix.python-version == 3.8
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
Something with codecov is not working right now, causing the 3.8 test to be labeled as failed.
This will not result in a failed test, but we should fix this soon anyway.