### PR TITLE
Install parameters on instance instead of class

### DIFF
--- a/concert/base.py
+++ b/concert/base.py
@@ -336,21 +336,21 @@ class Parameter(object):
     @memoize
     def setter_name(self):
         if self.fset:
-            return self.fset.__name__
+            return self.fset.__class__.__name__
 
         return '_set_' + self.name
 
     @memoize
     def getter_name(self):
         if self.fget:
-            return self.fget.__name__
+            return self.fget.__class__.__name__
 
         return '_get_' + self.name
 
     @memoize
     def getter_name_target(self):
         if self.fget_target:
-            return self.fget_target.__name__
+            return self.fget_target.__class__.__name__
 
         return '_get_target_' + self.name
 
@@ -1247,8 +1247,8 @@ class Parameterizable(AsyncObject):
             self._install_parameter(param)
 
         # Obtain the object-dot notation.
-        merged_dict = dict(list(self.__class__.__dict__.items()) + list(params.items()))
-        self.__class__ = type(self.__class__.__name__, self.__class__.__bases__, merged_dict)
+        #merged_dict = dict(list(self.__class__.__dict__.items()) + list(params.items()))
+        #self.__class__ = type(self.__class__.__name__, self.__class__.__bases__, merged_dict)
 
     def _install_parameter(self, param):
         if isinstance(param, Quantity):
@@ -1265,18 +1265,21 @@ class Parameterizable(AsyncObject):
         getter_name = 'get_' + param.name
         setter_name = 'set_' + param.name
         target_getter_name = 'get_target_' + param.name
-        if getter_name not in self.__class__.__dict__:
+        if getter_name not in self.__dict__:
             def get_parameter(instance, wait_on=None):
                 return instance[param.name].get(wait_on=wait_on)
-            setattr(self.__class__, getter_name, get_parameter)
-        if setter_name not in self.__class__.__dict__:
+            #setattr(self, getter_name, get_parameter)
+            self.__dict__[getter_name] = types.MethodType(get_parameter, self)
+        if setter_name not in self.__dict__:
             def set_parameter(instance, parameter_value, wait_on=None):
                 return instance[param.name].set(parameter_value, wait_on=wait_on)
-            setattr(self.__class__, setter_name, set_parameter)
-        if target_getter_name not in self.__class__.__dict__:
+            #setattr(self, setter_name, set_parameter)
+            self.__dict__[setter_name] = types.MethodType(set_parameter, self)
+        if target_getter_name not in self.__dict__:
             def get_target_parameter(instance, wait_on=None):
                 return instance[param.name].get_target(wait_on=wait_on)
-            setattr(self.__class__, target_getter_name, get_target_parameter)
+            #setattr(self, target_getter_name, get_target_parameter)
+            self.__dict__[target_getter_name] = types.MethodType(get_target_parameter, self)
 
         if not hasattr(self, '_set_' + param.name):
             setattr(self, '_set_' + param.name, _setter_not_implemented)


### PR DESCRIPTION
This should attach the parameters to the single instances and not to the class.

First tests are working:

```python
from concert.devices.motors.dummy import LinearMotor
from concert.base import Quantity

l = await LinearMotor()
l2 = await LinearMotor()
l2.install_parameters({"pos2": Quantity(q.deg)})

l
<concert.devices.motors.dummy.LinearMotor object at 0x7f10a94d39a0>
 Parameter        Value                        
 motion_velocity  200000.0 millimeter / second 
 position         5 millimeter                 
 state            standby  

l2
<concert.devices.motors.dummy.LinearMotor object at 0x7f10a89d6fb0>
 Parameter        Value                        
 motion_velocity  200000.0 millimeter / second 
 pos2             N/A                          
 position         0 millimeter                 
 state            standby  
```

The actual use-case of this is, when employing different uca-cameras.
With the class-wide implementation, each of the `concert.devices.camera.uca.Camera` adds all plugin-parameters to the uca.Camera class.