### PR TITLE
Fix timestamp checks for PCO cameras

### DIFF
--- a/concert/devices/cameras/pco.py
+++ b/concert/devices/cameras/pco.py
@@ -15,16 +15,16 @@ LOG = logging.getLogger(__name__)
 class Camera(UcaCamera):
     async def __ainit__(self, name="pco", params=None):
         self._timestamp_enabled = False
-        await super().__ainit__(name=name, params=params)
+        await UcaCamera.__ainit__(self, name=name, params=params)
 
     async def _record_real(self):
-        self._timestamp_enabled = await self.get_timestamp() in ['both', 'binary']
-        await super()._record_real()
+        self._timestamp_enabled = (await self.get_timestamp_mode()).value_name in ['UCA_PCO_CAMERA_TIMESTAMP_BINARY', 'UCA_PCO_CAMERA_TIMESTAMP_BOTH']
+        await UcaCamera._record_real(self)
 
     @background
     async def start_readout(self):
-        self._timestamp_enabled = await self.get_timestamp() in ['both', 'binary']
-        await super().start_readout()
+        self._timestamp_enabled = (await self.get_timestamp_mode()).value_name in ['UCA_PCO_CAMERA_TIMESTAMP_BINARY', 'UCA_PCO_CAMERA_TIMESTAMP_BOTH']
+        await UcaCamera.start_readout(self)
 
     @background
     async def grab(self) -> ImageWithMetadata:

--- a/concert/experiments/addons.py
+++ b/concert/experiments/addons.py
@@ -412,7 +412,6 @@ class PCOTimestampCheck(Addon):
             raise PCOTimestampCheckError("Not all images contained timestamps.")
 
 
-
 class AddonError(Exception):
     """Addon errors."""
 

--- a/concert/experiments/addons.py
+++ b/concert/experiments/addons.py
@@ -388,6 +388,7 @@ class PCOTimestampCheck(Addon):
         self.timestamp_missing = False
         i = 0
         last_acquisition = await self._experiment.acquisitions[-1].get_state() == "running"
+        first_frame = 1
         async for img in producer:
             if i == 0:
                 if not isinstance(img, ImageWithMetadata) or (
@@ -398,15 +399,18 @@ class PCOTimestampCheck(Addon):
                                                "Works only with pco cameras.")
                     self.timestamp_missing = True
                     return
-            if img.metadata['frame_number'] != i + 1:
+            if i == 0:
+                first_frame = img.metadata['frame_number']
+            if img.metadata['frame_number'] != i + first_frame:
                 self._experiment.log.error(
-                    f"Frame {i + 1} had wrong frame number {img.metadata['frame_number']}.")
+                    f"Frame {i} had wrong frame number {img.metadata['frame_number']} (first_frame: {first_frame}).")
                 self.timestamp_incorrect = True
             i += 1
         if last_acquisition and self.timestamp_incorrect:
             raise PCOTimestampCheckError("Not all 'frame_numbers' where correct.")
         if last_acquisition and self.timestamp_missing:
             raise PCOTimestampCheckError("Not all images contained timestamps.")
+
 
 
 class AddonError(Exception):

--- a/concert/experiments/addons.py
+++ b/concert/experiments/addons.py
@@ -399,7 +399,6 @@ class PCOTimestampCheck(Addon):
                                                "Works only with pco cameras.")
                     self.timestamp_missing = True
                     return
-            if i == 0:
                 first_frame = img.metadata['frame_number']
             if img.metadata['frame_number'] != i + first_frame:
                 self._experiment.log.error(


### PR DESCRIPTION
Fixes timestamp checks for PCO cameras.

This also ignores the index of the first frame and checks only if all subsequent frames are correctly aligned