### PR TITLE
Extend experiment logging

### DIFF
--- a/bin/concert
+++ b/bin/concert
@@ -12,6 +12,8 @@ import signal
 import subprocess
 import tempfile
 import zipfile
+from logging.handlers import TimedRotatingFileHandler
+
 import concert
 import concert.config
 import concert.session.management as cs
@@ -383,7 +385,7 @@ class StartCommand(SubCommand):
 
         if logto == 'file':
             logfilename = logfile if logfile else cs.logfile_path()
-            handler = logging.FileHandler(logfilename)
+            handler = TimedRotatingFileHandler(logfilename, when='W6')
         else:
             handler = logging.StreamHandler(sys.stderr)
 

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -151,6 +151,7 @@ class Experiment(Parameterizable):
             self._devices_to_log[name] = device
 
     async def log_to_json(self, directory: str, postfix: str = ''):
+        await self.prepare_logging()
         data = {}
         experiment_parameters = {}
         for param in self:
@@ -173,6 +174,7 @@ class Experiment(Parameterizable):
 
         with open(os.path.join(directory, f'experiment{postfix}.json'), 'w') as outfile:
             json.dump(data, outfile, indent=4)
+        await self.finish_logging()
 
     async def _get_iteration(self):
         return self._iteration
@@ -205,6 +207,15 @@ class Experiment(Parameterizable):
     async def finish(self):
         """Gets executed after every experiment run."""
         pass
+
+    async def prepare_logging(self):
+        """Function for preparing the device logging."""
+        pass
+
+    async def finish_logging(self):
+        """Function called after logging."""
+        pass
+
 
     @property
     def acquisitions(self):

--- a/concert/helpers.py
+++ b/concert/helpers.py
@@ -324,3 +324,31 @@ class ImageWithMetadata(np.ndarray):
         if obj is None:
             return
         self.metadata = getattr(obj, 'metadata', {})
+
+
+class Logger:
+    """
+    Logs devices and parameters to a json file. Each entry has the time (as utc string) as key.
+    """
+    def __init__(self, filename: str):
+        self._filename = filename
+        self._data = {}
+        self._saved = False
+
+    async def log(self, things_to_log: dict):
+        """
+            Dictionary with the things to log.
+        """
+        self._data[time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())] = things_to_log
+
+    def save(self):
+        if self._data == {}:
+            return
+        import json
+        with open(self._filename, 'w') as f:
+            json.dump(self._data, f, indent=4)
+        self._saved = True
+
+    def __del__(self):
+        if not self._saved:
+            self.save()


### PR DESCRIPTION
Unfortunately, there are often devices that will not work always... Therefore, I added the optional flag to the devices to log, so I can add a device to log, that is nice-to-have, but will not stop the experiment execution if it malfunctions.

I added also a second log at the end of the experiment execution. I think i is useful, but this is open for discussions.

I added a prepare and a finish function. Some devices need to be in a specific state to get useful data. In this function the user can handle such things.
