### PR TITLE
Proper implementation of 2D-slits

### DIFF
--- a/concert/devices/slits/base.py
+++ b/concert/devices/slits/base.py
@@ -1,0 +1,159 @@
+from concert.base import Quantity, Parameter, State, check
+from concert.devices.base import Device
+from concert.quantities import q
+from concert.devices.motors.base import LinearMotor
+
+
+class Slits(Device):
+    top = Quantity(q.mm, help='Top slit position',
+                   check=check(source='standby', state_name='vertical_state'))
+    bottom = Quantity(q.mm, help='Bottom slit position',
+                      check=check(source='standby', state_name='vertical_state'))
+    left = Quantity(q.mm, help='Left slit position',
+                    check=check(source='standby', state_name='horizontal_state'))
+    right = Quantity(q.mm, help='Right slit position',
+                     check=check(source='standby', state_name='horizontal_state'))
+    vertical_gap = Quantity(q.mm, help='Vertical gap',
+                            check=check(source='standby', state_name='vertical_state'))
+    horizontal_gap = Quantity(q.mm, help='Horizontal gap',
+                              check=check(source='standby', state_name='horizontal_state'))
+    vertical_offset = Quantity(q.mm, help='Vertical offset',
+                               check=check(source='standby', state_name='vertical_state'))
+    horizontal_offset = Quantity(q.mm, help='Horizontal offset',
+                                 check=check(source='standby', state_name='horizontal_state'))
+    horizontal_state = State(help='Horizontal state')
+    vertical_state = State(help='Vertical state')
+    area = Quantity(q.mm ** 2, help='Slit area')
+
+    async def __ainit__(self):
+        await super().__ainit__()
+
+    async def _get_area(self):
+        return await self.get_horizontal_gap() * await self.get_vertical_gap()
+
+
+class BladeSlits(Slits):
+    """
+    Slit that is composed of four blades. The blades can be moved independently.
+    Offsets and openings (gaps) are calculated from the blade positions.
+    """
+    # noinspection PyMethodOverriding
+    async def __ainit__(self,
+                        motor_top: LinearMotor,
+                        motor_bottom: LinearMotor,
+                        motor_left: LinearMotor,
+                        motor_right: LinearMotor,
+                        top_center=0 * q.mm,
+                        bottom_center=0 * q.mm,
+                        left_center=0 * q.mm,
+                        right_center=0 * q.mm,
+                        top_positive_out=True,
+                        bottom_positive_out=True,
+                        left_positive_out=True,
+                        right_positive_out=True):
+        """
+        Initialize the BladeSlits.
+
+        :param motor_top: Motor for the top blade.
+        :param motor_bottom: Motor for the bottom blade.
+        :param motor_left: Motor for the left blade.
+        :param motor_right: Motor for the right blade.
+        :param top_center: Center position for the top blade.
+        :param bottom_center: Center position for the bottom blade.
+        :param left_center: Center position for the left blade.
+        :param right_center: Center position for the right blade.
+        :param top_positive_out: True if the top blade moves outwards for positive positions.
+        :param bottom_positive_out: True if the bottom blade moves outwards for positive positions.
+        :param left_positive_out: True if the left blade moves outwards for positive positions.
+        :param right_positive_out: True if the right blade moves outwards for positive positions.
+
+        """
+        self._motor_top = motor_top
+        self._motor_bottom = motor_bottom
+        self._motor_left = motor_left
+        self._motor_right = motor_right
+
+        self._top_center = top_center
+        self._bottom_center = bottom_center
+        self._left_center = left_center
+        self._right_center = right_center
+
+        self._top_positive_out = top_positive_out
+        self._bottom_positive_out = bottom_positive_out
+        self._left_positive_out = left_positive_out
+        self._right_positive_out = right_positive_out
+
+        await super().__ainit__()
+
+    async def _get_vertical_state(self):
+        top_state = await self._motor_top.get_state()
+        bottom_state = await self._motor_bottom.get_state()
+        if 'moving' in [top_state, bottom_state]:
+            return 'moving'
+        if 'hard-limit' in [top_state, bottom_state]:
+            return 'hard-limit'
+        return 'standby'
+
+    async def _get_horizontal_state(self):
+        left_state = await self._motor_left.get_state()
+        right_state = await self._motor_right.get_state()
+        if left_state == 'moving' or right_state == 'moving':
+            return 'moving'
+        if left_state == 'hard-limit' or right_state == 'hard-limit':
+            return 'hard-limit'
+        return 'standby'
+
+    async def _get_top(self):
+        return (await self._motor_top.get_position() - self._top_center) * (1 if self._top_positive_out else -1)
+
+    async def _set_top(self, value):
+        await self._motor_top.set_position(value * (1 if self._top_positive_out else -1) + self._top_center)
+
+    async def _get_bottom(self):
+        return (await self._motor_bottom.get_position() - self._bottom_center) * (
+            1 if self._bottom_positive_out else -1)
+
+    async def _set_bottom(self, value):
+        await self._motor_bottom.set_position(value * (1 if self._bottom_positive_out else -1) + self._bottom_center)
+
+    async def _get_left(self):
+        return (await self._motor_left.get_position() - self._left_center) * (1 if self._left_positive_out else -1)
+
+    async def _set_left(self, value):
+        await self._motor_left.set_position(value * (1 if self._left_positive_out else -1) + self._left_center)
+
+    async def _get_right(self):
+        return (await self._motor_right.get_position() - self._right_center) * (1 if self._right_positive_out else -1)
+
+    async def _set_right(self, value):
+        await self._motor_right.set_position(value * (1 if self._right_positive_out else -1) + self._right_center)
+
+    async def _get_horizontal_gap(self):
+        return await self._motor_right.get_position() + await self._motor_left.get_position()
+
+    async def _set_horizontal_gap(self, value):
+        offset = await self.get_horizontal_offset()
+        await self._motor_right.set_position(value / 2 + offset)
+        await self._motor_left.set_position(value / 2 + offset)
+
+    async def _get_vertical_gap(self):
+        return await self._motor_top.get_position() + await self._motor_bottom.get_position()
+
+    async def _set_vertical_gap(self, value):
+        offset = await self.get_vertical_offset()
+        await self._motor_top.set_position(value / 2 + offset)
+        await self._motor_bottom.set_position(value / 2 + offset)
+
+    async def _get_horizontal_offset(self):
+        return (await self._motor_right.get_position() - await self._motor_left.get_position()) / 2
+
+    async def _get_vertical_offset(self):
+        return (await self._motor_top.get_position() - await self._motor_bottom.get_position()) / 2
+
+
+class GapSlits(Slits):
+    """
+    Slits that are composed of two sets of blades. The physical motors move the opening and the offset.
+    """
+    # TODO
+    pass

--- a/concert/devices/slits/dummy.py
+++ b/concert/devices/slits/dummy.py
@@ -1,0 +1,20 @@
+from concert.devices.motors.dummy import LinearMotor
+from concert.devices.slits.base import BladeSlits as BaseBladeSlits
+from concert.quantities import q
+
+
+class BladeSlits(BaseBladeSlits):
+    async def __ainit__(self):
+        await super().__ainit__(motor_top=await LinearMotor(position=1 * q.mm),
+                                motor_bottom=await LinearMotor(position=1 * q.mm),
+                                motor_left=await LinearMotor(position=1 * q.mm),
+                                motor_right=await LinearMotor(position=1 * q.mm),
+                                top_center=0 * q.mm,
+                                bottom_center=0 * q.mm,
+                                left_center=0 * q.mm,
+                                right_center=0 * q.mm,
+                                top_positive_out=True,
+                                bottom_positive_out=True,
+                                left_positive_out=True,
+                                right_positive_out=True
+                                )

--- a/concert/tests/unit/devices/test_slits.py
+++ b/concert/tests/unit/devices/test_slits.py
@@ -1,0 +1,85 @@
+import asyncio
+
+from concert.devices.slits.dummy import BladeSlits
+from concert.tests import TestCase
+from concert.quantities import q
+
+
+class TestBladeSlits(TestCase):
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.slits = await BladeSlits()
+
+    async def test_blades(self):
+        await self.slits.set_top(2 * q.mm)
+        self.assertEqual(2 * q.mm, await self.slits.get_top())
+
+        await self.slits.set_top(2 * q.mm)
+        self.assertEqual(2 * q.mm, await self.slits.get_top())
+
+        await self.slits.set_bottom(2 * q.mm)
+        self.assertEqual(2 * q.mm, await self.slits.get_bottom())
+
+        await self.slits.set_left(2 * q.mm)
+        self.assertEqual(2 * q.mm, await self.slits.get_left())
+
+    async def test_vertical_gap_offsets(self):
+        await self.slits.set_top(2 * q.mm)
+        await self.slits.set_bottom(2 * q.mm)
+        self.assertEqual(0 * q.mm, await self.slits.get_vertical_offset())
+        self.assertEqual(4 * q.mm, await self.slits.get_vertical_gap())
+
+        await self.slits.set_top(2 * q.mm)
+        await self.slits.set_bottom(0 * q.mm)
+        self.assertEqual(1 * q.mm, await self.slits.get_vertical_offset())
+        self.assertEqual(2 * q.mm, await self.slits.get_vertical_gap())
+
+    async def test_horizontal_gap_offset(self):
+        await self.slits.set_left(2 * q.mm)
+        await self.slits.set_right(2 * q.mm)
+        self.assertEqual(0 * q.mm, await self.slits.get_horizontal_offset())
+        self.assertEqual(4 * q.mm, await self.slits.get_horizontal_gap())
+
+        await self.slits.set_left(2 * q.mm)
+        await self.slits.set_right(0 * q.mm)
+        self.assertEqual(-1 * q.mm, await self.slits.get_horizontal_offset())
+        self.assertEqual(2 * q.mm, await self.slits.get_horizontal_gap())
+
+    async def test_states(self):
+        await self.slits.set_top(0 * q.mm)
+        await self.slits.set_bottom(0 * q.mm)
+        await self.slits.set_left(0 * q.mm)
+        await self.slits.set_right(0 * q.mm)
+
+        self.slits._motor_top.set_motion_velocity(1 * q.mm / q.s)
+        self.slits._motor_bottom.set_motion_velocity(1 * q.mm / q.s)
+        self.slits._motor_left.set_motion_velocity(1 * q.mm / q.s)
+        self.slits._motor_right.set_motion_velocity(1 * q.mm / q.s)
+
+        self.assertEqual('standby', await self.slits.get_vertical_state())
+        self.assertEqual('standby', await self.slits.get_horizontal_state())
+
+        f = self.slits.set_top(0.1 * q.mm)
+        await asyncio.sleep(0.01)
+        self.assertEqual('moving', await self.slits.get_vertical_state())
+        self.assertEqual('standby', await self.slits.get_horizontal_state())
+        await f
+
+        f = self.slits.set_bottom(0.1 * q.mm)
+        await asyncio.sleep(0.01)
+        self.assertEqual('moving', await self.slits.get_vertical_state())
+        self.assertEqual('standby', await self.slits.get_horizontal_state())
+        await f
+
+        f = self.slits.set_left(0.1 * q.mm)
+        await asyncio.sleep(0.01)
+        self.assertEqual('moving', await self.slits.get_horizontal_state())
+        self.assertEqual('standby', await self.slits.get_vertical_state())
+        await f
+
+        f = self.slits.set_right(0.1 * q.mm)
+        await asyncio.sleep(0.01)
+        self.assertEqual('moving', await self.slits.get_horizontal_state())
+        self.assertEqual('standby', await self.slits.get_vertical_state())
+        await f

--- a/concert/tests/unit/devices/test_slits.py
+++ b/concert/tests/unit/devices/test_slits.py
@@ -5,6 +5,14 @@ from concert.tests import TestCase
 from concert.quantities import q
 
 
+async def wait_for_state(device, state, state_name='state',  timeout=1.0*q.s):
+    start = asyncio.get_event_loop().time()
+    while await device[state_name].get() != state:
+        await asyncio.sleep(0.001)
+        if asyncio.get_event_loop().time() - start > timeout.to(q.s).magnitude:
+            raise TimeoutError()
+
+
 class TestBladeSlits(TestCase):
 
     async def asyncSetUp(self):
@@ -61,25 +69,25 @@ class TestBladeSlits(TestCase):
         self.assertEqual('standby', await self.slits.get_horizontal_state())
 
         f = self.slits.set_top(0.1 * q.mm)
-        await asyncio.sleep(0.01)
+        await wait_for_state(self.slits, 'moving', 'vertical_state')
         self.assertEqual('moving', await self.slits.get_vertical_state())
         self.assertEqual('standby', await self.slits.get_horizontal_state())
         await f
 
         f = self.slits.set_bottom(0.1 * q.mm)
-        await asyncio.sleep(0.01)
+        await wait_for_state(self.slits, 'moving', 'vertical_state')
         self.assertEqual('moving', await self.slits.get_vertical_state())
         self.assertEqual('standby', await self.slits.get_horizontal_state())
         await f
 
         f = self.slits.set_left(0.1 * q.mm)
-        await asyncio.sleep(0.01)
+        await wait_for_state(self.slits, 'moving', 'horizontal_state')
         self.assertEqual('moving', await self.slits.get_horizontal_state())
         self.assertEqual('standby', await self.slits.get_vertical_state())
         await f
 
         f = self.slits.set_right(0.1 * q.mm)
-        await asyncio.sleep(0.01)
+        await wait_for_state(self.slits, 'moving', 'horizontal_state')
         self.assertEqual('moving', await self.slits.get_horizontal_state())
         self.assertEqual('standby', await self.slits.get_vertical_state())
         await f


### PR DESCRIPTION
TODOs:
- [x] Allow multiple states per Parameterizable
- [ ] Add tests for multiple states
- [ ] Add some more documentation for the states
- [ ] Add slit implementations
   - [X] Slit with 4 motors, each moving one blade
   - [ ] Slit with motors moving the offset and gap
- [ ] Add tests for slits


About the multiple states:
We use multiple devices, that are composed of sub-devices, where the state-machine can be split in multiple state-machines. Therefore, I introduced the possibility to use multiple states.

```python
class ComplicatedDevice(Device):
   state_1 = State(default="standby")
   state_2 = State(default="standby")
   parameter_1 = Quantity(q.mm, check("standby", state_name="state_1")
   parameter_2 = Quantity(q.mm, check("standby", state_name="state_2")

   @transition(immediate="moving", target="standby", state_name="state_1")
   async def _set_parameter_1(self, p):
       # Do stuff

   @transition(immediate="moving", target="standby", state_name="state_2")
   async def _set_parameter_2(self, p):
       # Do stuff
```