### PR TITLE
fix: distinguish among loggers

### DIFF
--- a/concert/directors/base.py
+++ b/concert/directors/base.py
@@ -1,8 +1,7 @@
-import os
 import asyncio
 import logging
 
-from concert.base import Parameterizable, background, Parameter, State, transition, StateError, \
+from concert.base import Parameterizable, background, Parameter, State, StateError, \
     check, Selection
 from concert.helpers import get_state_from_awaitable
 from concert.loghandler import AsyncLoggingHandlerCloser
@@ -132,8 +131,9 @@ class Director(Parameterizable):
                 try:
                     await exp_run
                 except Exception as e:
+                    itr_name = await self.get_iteration_name(await self.get_iteration())
                     self.log.error(
-                        f"Director iteration {await self.get_iteration_name(await self.get_iteration())} failed.")
+                        f"Director iteration {itr_name} failed.")
                     self.log.error(e)
                     raise e
                 finally:

--- a/concert/directors/base.py
+++ b/concert/directors/base.py
@@ -5,7 +5,7 @@ import logging
 from concert.base import Parameterizable, background, Parameter, State, transition, StateError, \
     check, Selection
 from concert.helpers import get_state_from_awaitable
-from concert.loghandler import AsyncLoggingHandlerCloser, uid_for
+from concert.loghandler import AsyncLoggingHandlerCloser
 
 LOG = logging.getLogger(__name__)
 
@@ -100,9 +100,8 @@ class Director(Parameterizable):
         handler = None
         try:
             if self._experiment.walker:
-                handler: AsyncLoggingHandlerCloser = await self._experiment.walker.register_logger_with(
-                    uid=uid_for(self),
-                    log_name=self.__class__.__name__,
+                handler: AsyncLoggingHandlerCloser = await self._experiment.walker.register_logger(
+                    logger_name=self.__class__.__name__,
                     log_level=logging.NOTSET,
                     file_name="director.log"
                 )

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -17,6 +17,7 @@ from concert.coroutines.sinks import count
 from concert.progressbar import wrap_iterable
 from concert.base import check, Parameterizable, Parameter, Selection, State, StateError
 from concert.helpers import get_state_from_awaitable, get_basename
+from concert.loghandler import AsyncLoggingHandlerCloser, uid_for
 from functools import partial
 
 
@@ -422,7 +423,12 @@ class Experiment(Parameterizable):
             if separate_scans:
                 await self.walker.descend((await self.get_name_fmt()).format(iteration))
             if os.path.exists(await self.walker.get_current()):
-                handler = await self.walker.get_log_handler()
+                handler: AsyncLoggingHandlerCloser = await self.walker.register_logger_with(
+                    uid=uid_for(self),
+                    log_name=self.__class__.__name__,
+                    log_level=logging.NOTSET,
+                    file_name="experiment.log"
+                )
                 self.log.addHandler(handler)
                 exp_metadata: str = await self._prepare_metadata_str()
                 await self.walker.log_to_json(payload=exp_metadata)

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -17,7 +17,7 @@ from concert.coroutines.sinks import count
 from concert.progressbar import wrap_iterable
 from concert.base import check, Parameterizable, Parameter, Selection, State, StateError
 from concert.helpers import get_state_from_awaitable, get_basename
-from concert.loghandler import AsyncLoggingHandlerCloser, uid_for
+from concert.loghandler import AsyncLoggingHandlerCloser
 from functools import partial
 
 
@@ -423,9 +423,8 @@ class Experiment(Parameterizable):
             if separate_scans:
                 await self.walker.descend((await self.get_name_fmt()).format(iteration))
             if os.path.exists(await self.walker.get_current()):
-                handler: AsyncLoggingHandlerCloser = await self.walker.register_logger_with(
-                    uid=uid_for(self),
-                    log_name=self.__class__.__name__,
+                handler: AsyncLoggingHandlerCloser = await self.walker.register_logger(
+                    logger_name=self.__class__.__name__,
                     log_level=logging.NOTSET,
                     file_name="experiment.log"
                 )

--- a/concert/ext/tangoservers/walker.py
+++ b/concert/ext/tangoservers/walker.py
@@ -5,7 +5,7 @@ Implements a device server for file system traversal at remote host.
 """
 import logging
 import os
-from typing import Type, List, Dict, Tuple
+from typing import Type, Dict, Tuple
 from tango import DebugIt, DevState, CmdArgType
 from tango.server import attribute, command, AttrWriteType
 from concert.helpers import PerformanceTracker
@@ -90,7 +90,7 @@ class TangoRemoteWalker(TangoRemoteProcessing):
         await super().init_device()
         self._root = os.environ["HOME"]
         self._current = self._root
-        self._loggers = {} 
+        self._loggers = {}
         self._log_handlers = {}
         self.set_state(DevState.STANDBY)
         self.info_stream(

--- a/concert/ext/tangoservers/walker.py
+++ b/concert/ext/tangoservers/walker.py
@@ -192,8 +192,6 @@ class TangoRemoteWalker(TangoRemoteProcessing):
     )
     async def register_logger(self, args: Tuple[str, str, str]) -> str:
         logger_name, log_level, file_name = args[0], int(args[1]), args[2]
-        # NOTE: log_path functions as unique identifier for a logger instance as well as the
-        # absolute path for the log file, where logs should be written.
         log_path: str = os.path.join(self._current, file_name)
         handler = logging.FileHandler(log_path)
         logger = logging.Logger(logger_name, log_level)
@@ -207,24 +205,24 @@ class TangoRemoteWalker(TangoRemoteProcessing):
         dtype_in=str,
         doc_in="unique identifier for logger"
     )
-    async def deregister_logger(self, logger_id: str) -> None:
-        if logger_id in self._loggers and logger_id in self._log_handlers:
-            self._loggers[logger_id].removeHandler(self._log_handlers[logger_id])
-        self._log_handlers[logger_id].close()
-        del self._log_handlers[logger_id]
-        del self._loggers[logger_id]
+    async def deregister_logger(self, log_path: str) -> None:
+        if log_path in self._loggers and log_path in self._log_handlers:
+            self._loggers[log_path].removeHandler(self._log_handlers[log_path])
+        self._log_handlers[log_path].close()
+        del self._log_handlers[log_path]
+        del self._loggers[log_path]
 
     @DebugIt()
     @command(
         dtype_in=(str,),
-        doc_in="payload for logging, includes identifier, log_level and message"
+        doc_in="payload for logging, includes log_path as identifier, log_level and message"
     )
     async def log(self, payload: Tuple[str, str, str]) -> None:
-        logger_id, log_level, msg = payload[0], int(payload[1]), payload[2]
-        if logger_id in self._loggers:
-            self._loggers[logger_id].log(log_level, msg)
+        log_path, log_level, msg = payload[0], int(payload[1]), payload[2]
+        if log_path in self._loggers:
+            self._loggers[log_path].log(log_level, msg)
             self.info_stream("%s logged to file: %s - %s",
-                             self.__class__.__name__, logger_id, self.get_state())
+                             self.__class__.__name__, log_path, self.get_state())
 
     @DebugIt()
     @command(

--- a/concert/ext/tangoservers/walker.py
+++ b/concert/ext/tangoservers/walker.py
@@ -196,7 +196,7 @@ class TangoRemoteWalker(TangoRemoteProcessing):
         doc_in="log_name, log_level and file_name for logging",
         doc_out="absolute log file path as an identifier for the logger"
     )
-    async def register_logger(self, args: Tuple[str, str, str]) -> None:
+    async def register_logger(self, args: Tuple[str, str, str]) -> str:
         logger_name, log_level, file_name = args[0], int(args[1]), args[2]
         # NOTE: log_path functions as unique identifier for a logger instance as well as the
         # absolute path for the log file, where logs should be written.

--- a/concert/loghandler.py
+++ b/concert/loghandler.py
@@ -4,16 +4,16 @@ loghandler.py
 Encapsulates the log handling utilities for the walker APIs.
 """
 import asyncio
-import hashlib
 import logging
-import uuid
-from typing import List, Protocol, Callable, Any
+from typing import List, Protocol
 from concert.typing import RemoteDirectoryWalkerTangoDevice
 from concert.coroutines.base import get_event_loop
 
 #############
 # Protocols #
 ##############################################################################
+
+
 class AsyncLoggingHandlerCloser(Protocol):
     """Abstarct logging handler, which can be closed asynchronously"""
 
@@ -25,6 +25,8 @@ class AsyncLoggingHandlerCloser(Protocol):
         """Defines an asynchronous closing routine for logging handler"""
         ...
 ##############################################################################
+
+
 class NoOpLoggingHandler:
     """Defines placeholder handler closer which can be used for dummy
     implementation."""

--- a/concert/loghandler.py
+++ b/concert/loghandler.py
@@ -40,6 +40,24 @@ class NoOpLoggingHandler:
         ...
 
 
+class LoggingHandler(logging.FileHandler):
+    """Facilitates the logging utility for local directory traversal by
+    extending builtin logging.Handler object."""
+
+    def __init__(
+            self,
+            *args,
+            fmt: str = "[%(asctime)s] %(levelname)s: %(name)s: %(message)s") -> None:
+        super().__init__(*args)
+        self.setFormatter(logging.Formatter(fmt))
+
+    async def aflush(self) -> None:
+        super().flush()
+
+    async def aclose(self) -> None:
+        super().close()
+
+
 class RemoteLoggingHandler(logging.Handler):
     """
     Facilitates logging to file at a remote server in the network by extending

--- a/concert/loghandler.py
+++ b/concert/loghandler.py
@@ -46,28 +46,28 @@ class RemoteLoggingHandler(logging.Handler):
     """
 
     _device: RemoteDirectoryWalkerTangoDevice
-    _logger_id: str
+    _log_path: str
     _tasks: List[asyncio.Task]
     _loop: asyncio.AbstractEventLoop
 
     def __init__(
             self,
             device: RemoteDirectoryWalkerTangoDevice,
-            logger_id: str,
+            log_path: str,
             fmt: str = "[%(asctime)s] %(levelname)s: %(name)s: %(message)s") -> None:
         """
         Instantiates a remote handler for logging in remote host.
 
         :param device: device to send the log payload to write
         :type device: RemoteDirectoryWalkerTangoDevice
-        :param logger_id: unique identifier for the logger object
-        :type logger_id: str
+        :param log_path: log path as unique identifier for the logger object
+        :type log_path: str
         :param fmt: format for logging
         :type fmt: str
         """
         super().__init__()
         self._device = device
-        self._logger_id = logger_id
+        self._log_path = log_path
         self.setFormatter(logging.Formatter(fmt))
         self._loop = get_event_loop()
         self._tasks = []
@@ -82,7 +82,7 @@ class RemoteLoggingHandler(logging.Handler):
         """
         if self._loop:
             self._tasks.append(
-                asyncio.ensure_future(self._device.log([self._logger_id, str(record.levelno),
+                asyncio.ensure_future(self._device.log([self._log_path, str(record.levelno),
                                                         self.format(record)]), loop=self._loop))
         else:
             raise RuntimeError("event loop unavailable")
@@ -93,7 +93,7 @@ class RemoteLoggingHandler(logging.Handler):
 
     async def aclose(self) -> None:
         await self.aflush()
-        await self._device.deregister_logger(self._logger_id)
+        await self._device.deregister_logger(self._log_path)
         super().close()
 
 

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -8,10 +8,9 @@ import asyncio
 import os
 import logging
 import re
-
+from typing import Optional, AsyncIterable, Awaitable, Type, Iterable, Set
 import tango
 import zmq
-from typing import Optional, AsyncIterable, Awaitable, Type, Iterable, Set
 import tifffile
 from concert.base import Parameterizable, Parameter
 from concert.coroutines.base import background
@@ -19,7 +18,8 @@ from concert.networking.base import ZmqSender
 from concert.writers import TiffWriter
 from concert.typing import RemoteDirectoryWalkerTangoDevice
 from concert.typing import ArrayLike
-from concert.loghandler import AsyncLoggingHandlerCloser, NoOpLoggingHandler, RemoteLoggingHandler
+from concert.loghandler import AsyncLoggingHandlerCloser, NoOpLoggingHandler
+from concert.loghandler import LoggingHandler, RemoteLoggingHandler
 
 
 LOG = logging.getLogger(__name__)
@@ -441,8 +441,7 @@ class DirectoryWalker(Walker):
 
     async def register_logger(self, logger_name: str, log_level: int,
                               file_name: str) -> AsyncLoggingHandlerCloser:
-        # With decentralized concert logging utility is delegated to the remote directory walker
-        return NoOpLoggingHandler()
+        return LoggingHandler(os.path.join(await self.get_current(), file_name))
 
     async def log_to_json(self, payload: str) -> None:
         """

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -501,6 +501,8 @@ class RemoteDirectoryWalker(Walker):
         :type bytes_per_file: int
         """
         self.device = device
+        # NOTE: The method get_attribute_list is not a coroutine, hence should not be
+        # awaited.
         LOG.debug("device attributes: %s", self.device.get_attribute_list())
         # The 'root' is either explicitly specified or initialized using the
         # value from the remote server where the Tango device is initialized

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -610,13 +610,14 @@ class RemoteDirectoryWalker(Walker):
         """
         await self.device.write_sequence(name)
 
-    async def register_logger(self) -> AsyncLoggingHandlerCloser:
+    async def register_logger(self, logger_name: str, log_level: int,
+                              file_name: str) -> AsyncLoggingHandlerCloser:
         """
         Provides a logging handler for the current path, capable to facilitate
         logging at a remote host.
         """
-        logger_id: str = await self.device.register_logger((logger_name, str(log_level), file_name))
-        return RemoteLoggingHandler(device=self.device, logger_id=logger_id)
+        log_path: str = await self.device.register_logger((logger_name, str(log_level), file_name))
+        return RemoteLoggingHandler(device=self.device, log_path=log_path)
 
     async def log_to_json(self, payload: str) -> None:
         """Implements api layer for writing experiment metadata"""

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -145,7 +145,7 @@ async def write_images(producer: AsyncIterable[ArrayLike],
                     LOG.debug('Writer "{}" closed'.format(prefix.format(start_index
                                                                         + file_index - 1)))
                 im_writer = writer(prefix.format(start_index + file_index), bytes_per_file,
-                                   first_frame=start_index+i)
+                                   first_frame=start_index + i)
                 file_index += 1
                 written = 0
             if im_writer:
@@ -208,12 +208,12 @@ class Walker(Parameterizable):
         """Ascend from current depth."""
         raise NotImplementedError
 
-    async def _create_writer(self,
-                       producer: AsyncIterable[ArrayLike],
-                       dsetname: Optional[str] = None) -> Awaitable:
+    async def _create_writer(self, producer: AsyncIterable[ArrayLike],
+                             dsetname: Optional[str] = None) -> Awaitable:
         """
         Subclass should provide the implementation for, how the writer should
-        be created for asynchronously received data"""
+        be created for asynchronously received data
+        """
         raise NotImplementedError
 
     async def _get_current(self) -> str:
@@ -333,9 +333,8 @@ class DummyWalker(Walker):
         if self._current != self._root:
             self._current = os.path.dirname(self._current)
 
-    async def _create_writer(self,
-                       producer: AsyncIterable[ArrayLike],
-                       dsetname: Optional[str] = None) -> Awaitable:
+    async def _create_writer(self, producer: AsyncIterable[ArrayLike],
+                             dsetname: Optional[str] = None) -> Awaitable:
         dsetname = dsetname or await self.get_dsetname()
         path = os.path.join(self._current, dsetname)
 
@@ -350,6 +349,7 @@ class DummyWalker(Walker):
                               file_name: str) -> AsyncLoggingHandlerCloser:
         """Provides a no-op logging handler as a placeholder"""
         return NoOpLoggingHandler()
+
 
 class DirectoryWalker(Walker):
     """
@@ -409,9 +409,8 @@ class DirectoryWalker(Walker):
         """Provides start index from local context"""
         return self._start_index
 
-    async def _create_writer(self,
-                       producer: AsyncIterable[ArrayLike],
-                       dsetname: Optional[str] = None) -> Awaitable:
+    async def _create_writer(self, producer: AsyncIterable[ArrayLike],
+                             dsetname: Optional[str] = None) -> Awaitable:
         dsetname = dsetname or await self.get_dsetname()
         if self._dset_exists(dsetname):
             dset_prefix = split_dsetformat(dsetname)
@@ -575,10 +574,8 @@ class RemoteDirectoryWalker(Walker):
         """
         return await self.device.exists(paths)
 
-    async def _create_writer(
-        self,
-        producer: AsyncIterable[ArrayLike],
-        dsetname: Optional[str] = None) -> Awaitable:
+    async def _create_writer(self, producer: AsyncIterable[ArrayLike],
+                             dsetname: Optional[str] = None) -> Awaitable:
         old_endpoint = await self.get_endpoint()
         await self.set_endpoint(self._commdata.client_endpoint)
         old_dsetname = await self.get_dsetname()

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -610,7 +610,7 @@ class RemoteDirectoryWalker(Walker):
         """
         await self.device.write_sequence(name)
 
-    async def get_log_handler(self) -> AsyncLoggingHandlerCloser:
+    async def register_logger(self) -> AsyncLoggingHandlerCloser:
         """
         Provides a logging handler for the current path, capable to facilitate
         logging at a remote host.

--- a/concert/tests/integration/test_director.py
+++ b/concert/tests/integration/test_director.py
@@ -192,8 +192,8 @@ class XYScanDirectorTest(TestCase):
         self.assertEqual(await self.director.get_state(), "standby")
 
 
-class MockLoggingDirector(BaseDirector):
-    """Defines mock director to repeat a given number of experiments, so that some reasonable
+class TestableLoggingDirector(BaseDirector):
+    """Defines testable director to repeat a given number of experiments, so that some reasonable
     assertions can be made on the logging behavior"""
 
     _num_iter: int
@@ -240,7 +240,7 @@ class TestDirectorLogging(TestCase):
         self._experiment = await BaseExperiment(acquisitions=acquisitions, walker=self._walker)
         self._experiment.log = self._logger
         await self._experiment._set_log_level("debug")
-        self._direxp = await MockLoggingDirector(experiment=self._experiment,
+        self._direxp = await TestableLoggingDirector(experiment=self._experiment,
                                                  num_iter=self._director_iter, iter_name="iter")
         await super().asyncSetUp()
 
@@ -264,7 +264,7 @@ class TestDirectorLogging(TestCase):
         expected_register = 1 + 3 # director.log + (self._director_iter * experiment.log)
         self.assertTrue(mock_device.register_logger.call_count == expected_register)
         mock_device.register_logger.assert_has_calls([
-            mock.call((MockLoggingDirector.__name__, str(logging.NOTSET), "director.log")),
+            mock.call((TestableLoggingDirector.__name__, str(logging.NOTSET), "director.log")),
             mock.call(("Experiment", str(logging.NOTSET), "experiment.log")),
             mock.call(("Experiment", str(logging.NOTSET), "experiment.log")),
             mock.call(("Experiment", str(logging.NOTSET), "experiment.log"))

--- a/concert/tests/integration/test_director.py
+++ b/concert/tests/integration/test_director.py
@@ -226,9 +226,9 @@ class TestDirectorLogging(TestCase):
         self._visited = 0
         self._acquired = 0
         self._root = "root"
-        self._logger_id = "testable_logger_id"
+        self._log_path = "testable_logger_path"
         self._director_iter = 3
-        self._device = MockWalkerDevice(logger_id=self._logger_id)
+        self._device = MockWalkerDevice(log_path=self._log_path)
         self._walker = await RemoteDirectoryWalker(device=self._device, root=self._root)
         foo = await Acquisition("foo", self.produce, acquire=self.acquire)
         foo.add_consumer(AcquisitionConsumer(self.consume)), Tuple
@@ -271,10 +271,10 @@ class TestDirectorLogging(TestCase):
         ])
         expected_deregister = expected_register
         mock_device.deregister_logger.assert_has_calls([
-            mock.call(self._logger_id),
-            mock.call(self._logger_id),
-            mock.call(self._logger_id),
-            mock.call(self._logger_id)
+            mock.call(self._log_path),
+            mock.call(self._log_path),
+            mock.call(self._log_path),
+            mock.call(self._log_path)
         ])
         expected_json_logging = 3 # self._director_iter * experiment.log
         self.assertTrue(mock_device.log_to_json.call_count == expected_json_logging)

--- a/concert/tests/integration/test_experiments.py
+++ b/concert/tests/integration/test_experiments.py
@@ -4,13 +4,11 @@ files creation.
 """
 import asyncio
 import logging
-import os
 import os.path as op
 import tempfile
 import shutil
-from typing import Any, Tuple, Sequence
+from typing import Tuple
 import unittest
-import unittest.mock as mock
 import numpy as np
 from concert.quantities import q
 from concert.coroutines.base import start
@@ -227,7 +225,8 @@ class TestExperiment(TestExperimentBase):
 
     async def test_consumer_addon(self):
         accumulate = Accumulate()
-        consumer = await LocalConsumer(accumulate, experiment=self.experiment, acquisitions=[self.acquisitions[0]])
+        consumer = await LocalConsumer(accumulate, experiment=self.experiment,
+                                       acquisitions=[self.acquisitions[0]])
         await self.experiment.run()
         self.assertEqual(accumulate.items, list(range(self.num_produce)))
 
@@ -249,7 +248,6 @@ class TestExperiment(TestExperimentBase):
         finally:
             self.experiment.walker = None
             shutil.rmtree(data_dir)
-
 
     async def test_accumulation(self):
         acc = await LocalAccumulator(self.experiment)
@@ -334,7 +332,8 @@ class TestExperimentLogging(unittest.IsolatedAsyncioTestCase):
         self._experiment = await Experiment(acquisitions=self._acquisitions, walker=self._walker)
         await self._experiment._set_log_level("debug")
         self._devices = [await Shutter(), await LinearMotor(), await Camera()]
-        [self._experiment.add_device_to_log(f"Device-{dix}", dev) for dix, dev in enumerate(self._devices)]
+        [self._experiment.add_device_to_log(f"Device-{dix}", dev) for dix,
+         dev in enumerate(self._devices)]
         await super().asyncSetUp()
 
     async def asyncTearDown(self) -> None:
@@ -370,9 +369,8 @@ class TestExperimentLogging(unittest.IsolatedAsyncioTestCase):
         # DEBUG call for experiment iteration finish
         exp_debug_log = 1 + len(self._acquisitions) + 1 + 1
         mock_device = self._walker.device.mock_device
-        mock_device.register_logger.assert_called_once_with(
-                (Experiment.__name__, str(logging.NOTSET), "experiment.log"))
+        mock_device.register_logger.assert_called_once_with((Experiment.__name__,
+                                                             str(logging.NOTSET), "experiment.log"))
         self.assertEqual(mock_device.log.call_count, exp_info_log + exp_debug_log)
         mock_device.deregister_logger.assert_called_once_with(self._log_path)
         mock_device.log_to_json.assert_called_once()
-

--- a/concert/tests/integration/test_experiments.py
+++ b/concert/tests/integration/test_experiments.py
@@ -320,8 +320,8 @@ class TestExperimentLogging(TestCase):
         self._visited = 0
         self._acquired = 0
         self._root = "root"
-        self._logger_id = "testable_logger_id"
-        self._device = MockWalkerDevice(logger_id=self._logger_id)
+        self._log_path = "testable_logger_path"
+        self._device = MockWalkerDevice(log_path=self._log_path)
         self._walker = await RemoteDirectoryWalker(device=self._device, root=self._root)
         foo = await Acquisition("foo", self.produce, acquire=self.acquire)
         foo.add_consumer(AcquisitionConsumer(self.consume)), Tuple
@@ -358,8 +358,8 @@ class TestExperimentLogging(TestCase):
         mock_device = self._walker.device.mock_device
         mock_device.register_logger.assert_called_once_with(
                 (Experiment.__name__, str(logging.NOTSET), "experiment.log"))
-        mock_device.deregister_logger.assert_called_once_with(self._logger_id)
+        mock_device.deregister_logger.assert_called_once_with(self._log_path)
         mock_device.log_to_json.assert_called_once()
-        # TODO: Figure out why the remote handler does not get a call back in the tests, while it
-        # works inside a session.
+        # TODO: Figure out why the remote handler emit method does not get a call back in the
+        # tests, while it works inside a session.
 

--- a/concert/tests/util/mocks.py
+++ b/concert/tests/util/mocks.py
@@ -9,17 +9,18 @@ import asyncio
 import os
 import unittest.mock as mock
 from typing import Sequence, Any, Tuple
+import tango
 
 
 class MockWalkerDevice:
     """Attempts to mock the behavior of walker tango device server"""
 
     mock_device: mock.AsyncMock
-    _logger_id: str
+    _log_path: str
 
-    def __init__(self, logger_id: str) -> None:
+    def __init__(self, log_path: str) -> None:
         self.mock_device = mock.AsyncMock()
-        self._logger_id = logger_id
+        self._log_path = log_path
 
     async def write_attribute(self, attr_name: str, value: Any) -> None:
         await self.mock_device.write_attribute(attr_name=attr_name, value=value)
@@ -38,6 +39,9 @@ class MockWalkerDevice:
             mock_value.value = "some_value"
         return mock_value
 
+    def lock(self, lock_validity: int = tango.constants.DEFAULT_LOCK_VALIDITY) -> None:
+        self.mock_device.lock(lock_validity=tango.constants.DEFAULT_LOCK_VALIDITY)
+
     async def descend(self, name: str) -> None:
         await self.mock_device.descend(name=name)
         
@@ -52,10 +56,10 @@ class MockWalkerDevice:
     
     async def register_logger(self, args: Tuple[str, str, str]) -> str:
         await self.mock_device.register_logger(args)
-        return self._logger_id
+        return self._log_path
 
-    async def deregister_logger(self, logger_id: str) -> None:
-        await self.mock_device.deregister_logger(logger_id)
+    async def deregister_logger(self, log_path: str) -> None:
+        await self.mock_device.deregister_logger(log_path)
 
     async def log(self, payload: Tuple[str, str, str]) -> None:
         await self.mock_device.log(payload)

--- a/concert/tests/util/mocks.py
+++ b/concert/tests/util/mocks.py
@@ -3,11 +3,12 @@ mocks.py
 --------
 Encapsulates mock devices which can be used to replace device servers for remote tests. The idea
 is to approximately mock the async command invocations of the device servers, without actually
-running them.
+running them. We use `side_effect` to define the bare-minimum functionality for async method
+invocations, which we need for testing.
 """
 import os
 import unittest.mock as mock
-from typing import Sequence, Any, Tuple
+from typing import Sequence, Any, Tuple, List
 import tango
 
 
@@ -15,11 +16,36 @@ class MockWalkerDevice:
     """Attempts to mock the behavior of walker tango device server"""
 
     mock_device: mock.AsyncMock
-    _log_path: str
+    _root: str
+    _current: str
+    _registered_log_paths: List[str]
 
-    def __init__(self, log_path: str) -> None:
+    def _side_effect_descend(self, dir_name: str) -> None:
+        self._current = os.path.join(self._current, dir_name)
+        if not os.path.exists(self._current):
+            self._create_dir(self._current)
+
+    def _side_effect_ascend(self) -> None:
+        self._current = os.path.dirname(self._current)
+
+    def _side_effect_register_logger(self, args: Tuple[str, str, str]) -> str:
+        return os.path.join(self._current, args[2])
+
+    def _side_effect_deregister_logger(self, log_path: str) -> str:
+        if os.path.dirname(log_path) != self._root:
+            os.rmdir(os.path.dirname(log_path))
+
+    def __init__(self) -> None:
         self.mock_device = mock.AsyncMock()
-        self._log_path = log_path
+        self._root = os.environ["HOME"]
+        self._current = self._root
+        self._registered_log_paths = []
+        self.mock_device.descend = mock.AsyncMock(side_effect=self._side_effect_descend)
+        self.mock_device.ascend = mock.AsyncMock(side_effect=self._side_effect_ascend)
+        self.mock_device.register_logger = mock.AsyncMock(
+                side_effect=self._side_effect_register_logger)  # noqa E126
+        self.mock_device.deregister_logger = mock.AsyncMock(
+                side_effect=self._side_effect_deregister_logger)  # noqa E126
 
     async def write_attribute(self, attr_name: str, value: Any) -> None:
         await self.mock_device.write_attribute(attr_name=attr_name, value=value)
@@ -29,23 +55,33 @@ class MockWalkerDevice:
 
     async def __getitem__(self, key: Any) -> Any:
         mock_value = mock.MagicMock()
-        if key in ["current", "root"]:
-            # For current and root we pass HOME to ensure that the check for an existing path
-            # while running the experiment is satisfied. The actual path is irrelevant for
-            # testing.
-            mock_value.value = os.environ["HOME"]
+        # For current and root we pass HOME to ensure that the check for an existing path
+        # while running the experiment is satisfied. The actual path is irrelevant for
+        # testing.
+        if key == "root":
+            mock_value.value = self._root
+        elif key == "current":
+            mock_value.value = self._current
         else:
             mock_value.value = "some_value"
         return mock_value
 
     def lock(self, lock_validity: int = tango.constants.DEFAULT_LOCK_VALIDITY) -> None:
+        # TODO: This should be an async method but its invocations in current implementation are
+        # synchronous. When those are fixed it needs be fixed as well. When that is fixed we need
+        # to register corresponding mock.AsyncMock in constructor for consistency.
         self.mock_device.lock(lock_validity=tango.constants.DEFAULT_LOCK_VALIDITY)
 
     async def descend(self, name: str) -> None:
-        await self.mock_device.descend(name=name)
+        await self.mock_device.descend(name)
 
     async def ascend(self) -> None:
         await self.mock_device.ascend()
+
+    @staticmethod
+    def _create_dir(directory: str, mode: int = 0o0750) -> None:
+        if not os.path.exists(directory):
+            os.makedirs(name=directory, mode=mode)
 
     async def exists(self, paths: str) -> bool:
         await self.mock_device.exists(paths=paths)
@@ -54,8 +90,7 @@ class MockWalkerDevice:
         await self.mock_device.write_sequence(name=name)
 
     async def register_logger(self, args: Tuple[str, str, str]) -> str:
-        await self.mock_device.register_logger(args)
-        return self._log_path
+        return await self.mock_device.register_logger(args)
 
     async def deregister_logger(self, log_path: str) -> None:
         await self.mock_device.deregister_logger(log_path)

--- a/concert/tests/util/mocks.py
+++ b/concert/tests/util/mocks.py
@@ -58,7 +58,6 @@ class MockWalkerDevice:
         await self.mock_device.deregister_logger(logger_id)
 
     async def log(self, payload: Tuple[str, str, str]) -> None:
-        print(f"Mock device got a log call")
         await self.mock_device.log(payload)
 
     async def log_to_json(self, payload: str) -> None:

--- a/concert/tests/util/mocks.py
+++ b/concert/tests/util/mocks.py
@@ -1,0 +1,70 @@
+"""
+mocks.py
+--------
+Encapsulates mock devices which can be used to replace device servers for remote tests. The idea
+is to approximately mock the async command invocations of the device servers, without actually
+running them.
+"""
+import asyncio
+import os
+import unittest.mock as mock
+from typing import Sequence, Any, Tuple
+
+
+class MockWalkerDevice:
+    """Attempts to mock the behavior of walker tango device server"""
+
+    mock_device: mock.AsyncMock
+    _logger_id: str
+
+    def __init__(self, logger_id: str) -> None:
+        self.mock_device = mock.AsyncMock()
+        self._logger_id = logger_id
+
+    async def write_attribute(self, attr_name: str, value: Any) -> None:
+        await self.mock_device.write_attribute(attr_name=attr_name, value=value)
+
+    def get_attribute_list(self) -> Sequence[str]:
+        return []
+
+    async def __getitem__(self, key: Any) -> Any:
+        mock_value = mock.MagicMock()
+        if key in ["current", "root"]:
+            # For current and root we pass HOME to ensure that the check for an existing path
+            # while running the experiment is satisfied. The actual path is irrelevant for
+            # testing.
+            mock_value.value = os.environ["HOME"]
+        else:
+            mock_value.value = "some_value"
+        return mock_value
+
+    async def descend(self, name: str) -> None:
+        await self.mock_device.descend(name=name)
+        
+    async def ascend(self) -> None:
+        await self.mock_device.ascend()
+
+    async def exists(self, paths: str) -> bool:
+        await self.mock_device.exists(paths=paths)
+
+    async def write_sequence(self, name: str) -> None:
+        await self.mock_device.write_sequence(name=name)
+    
+    async def register_logger(self, args: Tuple[str, str, str]) -> str:
+        await self.mock_device.register_logger(args)
+        return self._logger_id
+
+    async def deregister_logger(self, logger_id: str) -> None:
+        await self.mock_device.deregister_logger(logger_id)
+
+    async def log(self, payload: Tuple[str, str, str]) -> None:
+        print(f"Mock device got a log call")
+        await self.mock_device.log(payload)
+
+    async def log_to_json(self, payload: str) -> None:
+        await self.mock_device.log_to_json(payload)
+
+
+if __name__ == "__main__":
+    pass
+

--- a/concert/tests/util/mocks.py
+++ b/concert/tests/util/mocks.py
@@ -5,7 +5,6 @@ Encapsulates mock devices which can be used to replace device servers for remote
 is to approximately mock the async command invocations of the device servers, without actually
 running them.
 """
-import asyncio
 import os
 import unittest.mock as mock
 from typing import Sequence, Any, Tuple
@@ -44,7 +43,7 @@ class MockWalkerDevice:
 
     async def descend(self, name: str) -> None:
         await self.mock_device.descend(name=name)
-        
+
     async def ascend(self) -> None:
         await self.mock_device.ascend()
 
@@ -53,7 +52,7 @@ class MockWalkerDevice:
 
     async def write_sequence(self, name: str) -> None:
         await self.mock_device.write_sequence(name=name)
-    
+
     async def register_logger(self, args: Tuple[str, str, str]) -> str:
         await self.mock_device.register_logger(args)
         return self._log_path
@@ -70,4 +69,3 @@ class MockWalkerDevice:
 
 if __name__ == "__main__":
     pass
-

--- a/concert/typing.py
+++ b/concert/typing.py
@@ -124,7 +124,7 @@ class RemoteDirectoryWalkerTangoDevice(
         """
         ...
 
-    async def deregister_logger(self, logger_id: str) -> None:
+    async def deregister_logger(self, log_path: str) -> None:
         """
         Deallocates the file handler and logger for provided logger id
         """
@@ -133,7 +133,7 @@ class RemoteDirectoryWalkerTangoDevice(
     async def log(self, payload: Tuple[str, str, str]) -> None:
         """
         Facilitates logging using a specific logger from the maintained loggers. Payload
-        consists of logger id, logging level and log message.
+        consists of log path as identifier for logger, logging level and log message.
         """
         ...
 #####################################################################

--- a/concert/typing.py
+++ b/concert/typing.py
@@ -5,7 +5,7 @@ typing.py
 ---------
 Facilitates type annotations for concert
 """
-from typing import Protocol, Any, NewType, Sequence
+from typing import Protocol, Any, NewType, Sequence, Tuple
 import numpy
 
 # Defines ArrayLike as a new type
@@ -117,23 +117,23 @@ class RemoteDirectoryWalkerTangoDevice(
         :type path: str
         """
 
-    async def open_log_file(self, file_path: str) -> None:
+    async def register_logger(self, args: Tuple[str, str, str]) -> None:
         """
-        Opens a log file for writing logs asynchronously.
-        :param file_path: absolute path to the log file
-        :type file_path: str
+        Registers a logger and corresponding file handler with provided logger name,
+        logging level and log file name as tuple
         """
         ...
 
-    async def close_log_file(self) -> None:
-        """Closes the log file if its open"""
+    async def deregister_logger(self, logger_id: str) -> None:
+        """
+        Deallocates the file handler and logger for provided logger id
+        """
         ...
 
-    async def log(self, payload: str) -> None:
+    async def log(self, payload: Tuple[str, str, str]) -> None:
         """
-        Writes log to the log file.
-        :param payload: arbitrary log payload as a string
-        :type payload: str
+        Facilitates logging using a specific logger from the maintained loggers. Payload
+        consists of logger id, logging level and log message.
         """
         ...
 #####################################################################


### PR DESCRIPTION
**Premise**: To facilitate logging during complex experiment scenarios we want to refactor remote logger implementation. In this first proposal we refactor remote walker device server to maintain a dictionary of loggers and respective handlers corresponding to the experiment or director objects, which holds reference to them. Writing tests and review are underway.

This implementation can be demonstrated with the following concert session using director.

```python
import asyncio
import logging
import os
from inspect import iscoroutinefunction
import numpy as np
import zmq
import concert
from concert.experiments.addons import tango as tango_addons
from concert.quantities import q
from concert.devices.motors.dummy import LinearMotor, ContinuousRotationMotor
from concert.devices.shutters.dummy import Shutter
from concert.storage import RemoteDirectoryWalker
from concert.ext.viewers import PyQtGraphViewer
from concert.networking.base import get_tango_device
from concert.experiments.synchrotron import RemoteRadiography
from concert.devices.cameras.uca import RemoteNetCamera
from concert.directors.base import Director
from concert.helpers import CommData


# Run Camera: ucad mock
# Run Acquisitions Walker Writer: concert tango walker --loglevel perfdebug --port 7001
# Run Reconstruction: concert tango reco --loglevel perfdebug --port 7002
# Run Reconstruction Walker Writer: concert tango walker --loglevel perfdebug --port 7003

# Camera
camera = await RemoteNetCamera()
if await camera.get_state() == 'recording':
    await camera.stop_recording()

await camera.set_roi_width(512 * q.px)
await camera.set_roi_height(512 * q.px)
await camera.set_frame_rate(20 / q.s)
await camera.set_fill_data(True)

SERVERS = {
        "walker": CommData("localhost", port=8997, socket_type=zmq.PUSH),
        "reco": CommData("localhost", port=8993, socket_type=zmq.PUSH),
        "live": CommData("localhost", port=8995, socket_type=zmq.PUB, sndhwm=1)
}

for com in SERVERS.values():
    try:
        await camera.register_endpoint(com.server_endpoint, com.socket_type, sndhwm=com.sndhwm)
    except Exception as e:
        print(f"re-registering `{com.server_endpoint}'")
        await camera.unregister_endpoint(com.server_endpoint)
        await camera.register_endpoint(com.server_endpoint, com.socket_type)

# Walker
root = "/home/ws/nj4412/workspace/projects/testbed/concert_dev_tests/root"
walker_dev_uri = f"{os.uname()[1]}:7001/concert/tango/walker#dbase=no"
walker_device = get_tango_device(walker_dev_uri)
await walker_device.write_attribute('endpoint', SERVERS["walker"].client_endpoint)
walker = await RemoteDirectoryWalker(device=walker_device, root=root, bytes_per_file=2**40)

# Experiment
shutter = await Shutter()
flat_motor = await LinearMotor()
tomo = await ContinuousRotationMotor()
exp = await RemoteRadiography(walker=walker, camera=camera, shutter=shutter, flat_motor=flat_motor,
                              radio_position=0*q.mm, flat_position=10*q.mm, 
                              num_darks=5, num_flats=5, num_projections=50)
exp.add_device_to_log("MockUCACamera", camera)
exp.add_device_to_log("MockShutter", shutter)
exp.add_device_to_log("MockMotor", flat_motor)

# Director
class DummyDirector(Director):

    _num_iter: int
    _iter_name: str
    
    async def __ainit__(self, experiment: RemoteRadiography, num_iter: int, iter_name: str) -> None:
        self._num_iter = num_iter
        self._iter_name = iter_name
        await super().__ainit__(experiment=experiment)

    async def _get_number_of_iterations(self) -> int:
        return self._num_iter

    async def _prepare_run(self, iteration: int) -> None:
        self.log.info(f"Preparing iteration: {iteration}")

    async def _get_iteration_name(self, iteration: int) -> str:
        return f"{self._iter_name}_{iteration:04d}" 

    async def get_iteration_name(self, iteration: int) -> str:
        return self._get_iteration_name(iteration)

    async def get_iteration(self) -> int:
        return self._get_current_iteration()

dexp = await DummyDirector(experiment=exp, num_iter=3, iter_name="direxp0")

# Writer
writer = await tango_addons.ImageWriter(exp, exp.acquisitions)

# Live View
viewer = await PyQtGraphViewer(show_refresh_rate=True)
viewer.subscribe(SERVERS["live"].client_endpoint)

# Reconstruction
remote_reco_walker_dev_uri = f"{os.uname()[1]}:7003/concert/tango/walker#dbase=no"
remote_reco_walker_device = get_tango_device(remote_reco_walker_dev_uri)
remote_reco_walker = await RemoteDirectoryWalker(device=remote_reco_walker_device, root=root,
                                           bytes_per_file=2**40)

reco_dev_uri = f"{os.uname()[1]}:7002/concert/tango/reco#dbase=no"
reco_device = get_tango_device(reco_dev_uri)
await reco_device.write_attribute('endpoint', SERVERS["reco"].client_endpoint)
await reco_device.setup_walker(
    [remote_reco_walker_dev_uri, root, "tcp", "localhost", "8996"]
)
reco = await tango_addons.OnlineReconstruction(reco_device, exp, do_normalization=True,
                                               average_normalization=True,
                                               slice_directory="online-slices")
await reco.set_region([-256., 256., 5.])
await reco.set_center_position_x([256.0] * q.px)
await reco.set_fix_nan_and_inf(True)
await reco_device.write_attribute('center_position_z',
                                  [(await camera.get_roi_height()).magnitude / 2 + 0.5])
await reco_device.write_attribute('number', 50)
await reco_device.write_attribute('overall_angle', np.pi)

_ = reco.reconstruct()

# f = await dexp.run()
```