### PR TITLE
Enhancement: add endpoint registration to base camera

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -9,7 +9,7 @@ import struct
 from concert.coroutines.base import background, run_in_executor
 from concert.quantities import q
 from concert.base import check, Parameter, Quantity
-from concert.helpers import Bunch
+from concert.helpers import Bunch, CommData
 from concert.devices.cameras import base
 
 
@@ -287,13 +287,14 @@ class RemoteNetCamera(Camera):
     async def _grab_send_real(self, num, end=True):
         await self._send_grab_push_command(num_images=num, end=end)
 
-    async def register_endpoint(self, endpoint, socket_type, sndhwm=-1):
+    async def register_endpoint(self, endpoint: CommData) -> None:
         await self._communicate(
-            struct.pack("I128sii", 12, bytes(endpoint, 'ascii'), socket_type, sndhwm)
+            struct.pack("I128sii", 12, bytes(endpoint.server_endpoint, 'ascii'),
+                        endpoint.socket_type, endpoint.sndhwm)
         )
 
-    async def unregister_endpoint(self, endpoint):
-        await self._communicate(struct.pack("I128s", 13, bytes(endpoint, 'ascii')))
+    async def unregister_endpoint(self, endpoint: CommData) -> None:
+        await self._communicate(struct.pack("I128s", 13, bytes(endpoint.server_endpoint, 'ascii')))
 
 
 def _construct_ucad_error(message):

--- a/concert/helpers.py
+++ b/concert/helpers.py
@@ -410,6 +410,18 @@ class CommData:
         else:
             return f"{self.protocol}://{self.host}:{self.port}"
 
+    def __eq__(self, other: CommData) -> bool:
+        for key, value in self.__dict__.items():
+            if other.__dict__[key] != value:
+                return False
+        return True
+
+    def __ne__(self, other: CommData) -> bool:
+        return not self.__eq__(other)
+
+    def __hash__(self) -> int:
+        return hash((self.host, self.port, self.protocol, self.socket_type, self.sndhwm))
+
 
 def get_basename(filename):
     if filename.endswith(os.sep):

--- a/concert/tests/unit/devices/test_camera.py
+++ b/concert/tests/unit/devices/test_camera.py
@@ -1,9 +1,13 @@
 from datetime import datetime
-import numpy as np
+from unittest import mock
+import numpy as np 
+import zmq
 from concert.tests import TestCase
 from concert.quantities import q
 from concert.devices.cameras.dummy import Camera, BufferedCamera
 from concert.devices.cameras.pco import Timestamp, TimestampError
+from concert.helpers import CommData
+from concert.networking.base import ZmqSender
 
 
 class TestDummyCamera(TestCase):
@@ -85,6 +89,41 @@ class TestDummyCamera(TestCase):
         camera = await Camera(background=self.background, simulate=False)
         async with camera.recording():
             np.testing.assert_equal(self.background, await camera.grab())
+
+#    async def test_endpoint_registration(self) -> None:
+#
+#        async def mock_register_endpoint(self, endpoint: CommData) -> None:
+#            if endpoint in self._senders:
+#                raise ValueError("zmq endpoint already in list")
+#            self._senders[endpoint] = mock.MagicMock(
+#                endpoint.server_endpoint,
+#                reliable=endpoint.socket_type == zmq.PUSH,
+#                sndhwm=endpoint.sndhwm
+#            )
+#
+#        comm1 = CommData(host="localhost", port=8991, protocol="tcp", socket_type=zmq.PUSH,
+#                         sndhwm=0)
+#        comm2 = CommData(host="localhost", port=8991, protocol="tcp", socket_type=zmq.PUSH,
+#                         sndhwm=0)
+#        comm3 = CommData(host="localhost", port=8992, protocol="tcp", socket_type=zmq.PUSH,
+#                         sndhwm=0)
+#        self.assertTrue(comm1 == comm2)
+#        fqn_func = "concert.devices.cameras.base.Camera.register_endpoint"
+#        with mock.patch(fqn_func, wraps=mock_register_endpoint) as mre:
+#            try:
+#                await self.camera.register_endpoint(endpoint=comm1)
+#            except Exception:
+#                self.fail("first endpoint registration must not fail")
+#            with self.assertRaises(ValueError):
+#                await self.camera.register_endpoint(endpoint=comm2)
+#            try:
+#                await self.camera.register_endpoint(endpoint=comm3)
+#            except Exception:
+#                self.fail("new endpoint registration must not fail")
+#            try:
+#                await self.camera.unregister_endpoint(endpoint=comm1)
+#            except Exception:
+#                self.fail("removing a registered endpoint must not fail")
 
 
 class TestPCOTimeStamp(TestCase):

--- a/concert/tests/unit/test_helpers.py
+++ b/concert/tests/unit/test_helpers.py
@@ -221,6 +221,7 @@ class TestVarious(TestCase):
 
 
 class TestCommData(TestCase):
+
     def test_tcp(self):
         comms = CommData("localhost", port=1234, protocol="tcp", socket_type=zmq.PUSH, sndhwm=1234)
         self.assertEqual(comms.server_endpoint, "tcp://*:1234")
@@ -239,3 +240,21 @@ class TestCommData(TestCase):
     def test_wrong_protocols(self):
         with self.assertRaises(ValueError):
             comms = CommData("localhost", protocol="foo")
+
+    def test_equality(self) -> None:
+        comm1 = CommData(host="localhost", port=8991, protocol="tcp", socket_type=zmq.PUB,
+                         sndhwm=-1)
+        comm2 = CommData(host="localhost", port=8991, protocol="tcp", socket_type=zmq.PUB,
+                         sndhwm=-1)
+        comm3 = CommData(host="localhost", port=8992, protocol="tcp", socket_type=zmq.PUB,
+                         sndhwm=-1)
+        self.assertEqual(comm1, comm2)
+        self.assertTrue(comm1 == comm2)
+        self.assertNotEqual(comm1, comm3)
+        self.assertFalse(comm2 == comm3)
+
+    def test_hash_function(self) -> None:
+        comm1 = CommData(host="localhost", port=8991, protocol="tcp", socket_type=zmq.PUB,
+                         sndhwm=-1)
+        self.assertTrue(hash(comm1) == hash(("localhost", 8991, "tcp", zmq.PUB, -1)))
+        self.assertFalse(hash(comm1) == hash(("localhost", 8991, "tcp", zmq.PUSH, -1)))


### PR DESCRIPTION
**Premise**: To make a concert session with multiple utilities such as remote writing, online reconstruction, qa etc. we need to enable the base camera class to accommodate multiple endpoints like the UCA network camera. In the proposed change we enable the base camera class to maintain a group of senders internally instead of one.

Following concert session is used to test the functionality.

```python
import asyncio
import logging
import os
from inspect import iscoroutinefunction
import numpy as np
import zmq
import concert
from concert.experiments.addons import tango as tango_addons
from concert.quantities import q
from concert.devices.motors.dummy import LinearMotor, ContinuousRotationMotor
from concert.devices.shutters.dummy import Shutter
from concert.storage import RemoteDirectoryWalker
from concert.ext.viewers import PyQtGraphViewer
from concert.networking.base import get_tango_device
from concert.experiments.synchrotron import RemoteRadiography
from concert.devices.cameras.dummy import FileCamera
from concert.devices.cameras.uca import RemoteNetCamera
from concert.helpers import CommData

# File pattern or ucad mock
# Run Acquisitions Walker Writer: concert tango walker --loglevel perfdebug --port 7001
# Run Reconstruction: concert tango reco --loglevel perfdebug --port 7002
# Run Reconstruction Walker Writer: concert tango walker --loglevel perfdebug --port 7003

# Camera
pattern = "/home/ws/nj4412/workspace/projects/analytical_methods/data/measurements/tiff5x/image_seq/*.tif"
camera = await FileCamera(pattern=pattern)
# OR
# camera = await RemoteNetCamera()
if await camera.get_state() == 'recording':
    await camera.stop_recording()

await camera.set_roi_width(2016 * q.px)
await camera.set_roi_height(2016 * q.px)
await camera.set_frame_rate(20 / q.s)
#await camera.set_fill_data(True)

SERVERS = {
        "walker": CommData("localhost", port=8997, socket_type=zmq.PUSH),
        "reco": CommData("localhost", port=8993, socket_type=zmq.PUSH),
        "live": CommData("localhost", port=8995, socket_type=zmq.PUB, sndhwm=1)
}

for comm in SERVERS.values():
    try:
        await camera.register_endpoint(comm)
    except Exception as e:
        print(f"re-registering `{comm.server_endpoint}'")
        await camera.unregister_endpoint(comm)
        await camera.register_endpoint(comm)

# Walker
root = "/home/ws/nj4412/workspace/projects/testbed/concert_dev_tests/root"
walker_dev_uri = f"{os.uname()[1]}:7001/concert/tango/walker#dbase=no"
walker_device = get_tango_device(walker_dev_uri)
await walker_device.write_attribute('endpoint', SERVERS["walker"].client_endpoint)
walker_device.set_timeout_millis(300000)
walker = await RemoteDirectoryWalker(device=walker_device, root=root, bytes_per_file=2**40)

# Experiment
shutter = await Shutter()
flat_motor = await LinearMotor()
tomo = await ContinuousRotationMotor()
exp = await RemoteRadiography(walker=walker, camera=camera, shutter=shutter, flat_motor=flat_motor,
                              radio_position=0*q.mm, flat_position=10*q.mm, 
                              num_darks=100, num_flats=200, num_projections=3000)
exp.add_device_to_log("MockFileCamera", camera)
exp.add_device_to_log("MockShutter", shutter)
exp.add_device_to_log("MockMotor", flat_motor)

# Writer
writer = await tango_addons.ImageWriter(exp, exp.acquisitions)

# Live View
viewer = await PyQtGraphViewer(show_refresh_rate=True)
viewer.subscribe(SERVERS["live"].client_endpoint)

# Reconstruction
remote_reco_walker_dev_uri = f"{os.uname()[1]}:7003/concert/tango/walker#dbase=no"
remote_reco_walker_device = get_tango_device(remote_reco_walker_dev_uri)
remote_reco_walker_device.set_timeout_millis(600000)
remote_reco_walker = await RemoteDirectoryWalker(device=remote_reco_walker_device, root=root,
                                           bytes_per_file=2**40)

reco_dev_uri = f"{os.uname()[1]}:7002/concert/tango/reco#dbase=no"
reco_device = get_tango_device(reco_dev_uri)
await reco_device.write_attribute('endpoint', SERVERS["reco"].client_endpoint)
reco_device.set_timeout_millis(500000)
await reco_device.setup_walker(
    [remote_reco_walker_dev_uri, root, "tcp", "localhost", "8996"]
)
reco = await tango_addons.OnlineReconstruction(reco_device, exp, do_normalization=True,
                                               average_normalization=True,
                                               slice_directory="online-slices")
await reco.set_region([-700., 700., 1.])
await reco.set_center_position_x([1012.8] * q.px)
await reco.set_fix_nan_and_inf(True)
await reco_device.write_attribute('center_position_z',
                                  [(await camera.get_roi_height()).magnitude / 2 + 0.5])
await reco_device.write_attribute('number', 3000)
await reco_device.write_attribute('overall_angle', np.pi)
_ = reco.reconstruct()
```
**DEVICE TIMEOUT**: Just as a note for the session attached to the PR, the aspect of Tango device timeout is still a pressing matter, at least from the context of running local sessions with real data. To counter this I used large values to set the device timeouts to make sure, that I can work with realistic scenarios (i.e. ~100 darks, ~200 flats, ~3000 projections) and to rerun the session I needed to restart the device servers.

Also I noticed a particular aspect of the session, which is that the remote walker device to write online slices has to wait longer compared to all other devices. Even after setting a larger timeout to it I could not counter the situation, that it could only write upto ~600 reconstructed slices. Not only the walker device timed out, but also I saw this error "No listeners or queue full on b'tcp://0.0.0.0:8996'" at the reco device when it tried to push the online slices for writing at some point.

I have not seen this situation while looking at online reconstruction for real acquisitions. One probable reason could be, that I am reading a lot of files from the disk for he file camera and working with a single GPU and it is becoming a bottleneck. But I still wanted to make this note because it might be relevant.
