### PR TITLE
Adds qt-like signals to Parameters

### DIFF
--- a/concert/tests/unit/test_signals.py
+++ b/concert/tests/unit/test_signals.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from concert.tests import TestCase
+from concert.quantities import q
+from concert.devices.motors.dummy import LinearMotor
+
+
+class TestSignal(TestCase):
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.motor1 = await LinearMotor()
+        self.motor2 = await LinearMotor()
+
+    async def test_value_set_connect_and_disconnect(self):
+        await self.motor1.set_position(10 * q.mm)
+        await self.motor2.set_position(20 * q.mm)
+        self.assertEqual(await self.motor1.get_position(), 10 * q.mm)
+        self.assertEqual(await self.motor2.get_position(), 20 * q.mm)
+
+        # Connect setting of motor1 to also set motor2 to the same position
+        self.motor1['position'].value_set.connect(self.motor2, self.motor2.set_position)
+        await self.motor1.set_position(25 * q.mm)
+
+        # We made the pseudo motors to 'realistic'
+        await asyncio.sleep(0.1)
+        while self.motor2.get_state() == "moving":
+            await asyncio.sleep(0.01)
+
+        self.assertEqual(await self.motor1.get_position(), 25 * q.mm)
+        self.assertEqual(await self.motor2.get_position(), 25 * q.mm)
+
+        # Make sure that disconnecting the signal works
+        self.motor1['position'].value_set.disconnect(self.motor2, self.motor2.set_position)
+        await self.motor1.set_position(10 * q.mm)
+        await self.motor2.set_position(20 * q.mm)
+
+        self.assertEqual(await self.motor1.get_position(), 10 * q.mm)
+        self.assertEqual(await self.motor2.get_position(), 20 * q.mm)
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'scipy',
         'tifffile',
         'pyzmq>=23.2.1',
-        'psutil'
+        'psutil',
+        'pynnex'
     ],
     test_suite='concert.tests',
 )


### PR DESCRIPTION
I was looking for an elegant way to connect different Parameterizable-Parameters and had this idea.

This uses https://github.com/nexconnectio/pynnex which implements qt-like signals and slots and is quite light-weight. Currently, the development is quite active and looks clean.

Example:
```python
from concert.devices.cameras.dummy import Camera
camera = await Camera()

def print_value(val):
   print(value)

camera['exposure_time'].value_set.connect(print_value)
camera.exposure = 1*q.s


exp = await CT(...)
reco = await OnlineReco(...)

exp['num_projections'].value_set.connect(reco, reco.set_number)

```

One motivation for this would be to couple experiment parameters with addon-parameters (the number of the online-reco couples with the num_projections of the CT experiment).

TODO:
- [ ] Tests
- [ ] Doc