### PR TITLE
Fix uca grab lock

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -203,18 +203,17 @@ class Camera(base.Camera):
 
     @_translate_gerror
     async def _grab_real(self, index=None):
-        async with self._grab_lock:
-            if self._record_shape is None:
-                await self._determine_shape_for_grab()
-            array = np.empty(self._record_shape, dtype=self._record_dtype)
-            data = array.__array_interface__['data'][0]
+        if self._record_shape is None:
+            await self._determine_shape_for_grab()
+        array = np.empty(self._record_shape, dtype=self._record_dtype)
+        data = array.__array_interface__['data'][0]
 
-            if index is None:
-                await run_in_executor(self.uca.grab, data)
-            else:
-                await run_in_executor(self.uca.readout, data, index)
+        if index is None:
+            await run_in_executor(self.uca.grab, data)
+        else:
+            await run_in_executor(self.uca.readout, data, index)
 
-            return array
+        return array
 
     async def _determine_shape_for_grab(self):
         self._record_shape = ((await self.get_roi_height()).magnitude,

--- a/concert/tests/integration/scenarios/test_experiment.py
+++ b/concert/tests/integration/scenarios/test_experiment.py
@@ -1,41 +1,26 @@
 """
 test_experiment.py
 ------------------
-Encapsulates remote experiment test cases
+Base class for experiment test cases with common functionality
 """
 import json
 import os
 import shutil
 import skimage.io as skio
-import zmq
 from pathlib import Path
 from typing import List, Any, Dict
 from numpy import ndarray as ArrayLike
-from concert.experiments.addons import tango as tango_addons
-from concert.quantities import q
-from concert.devices.motors.dummy import LinearMotor, ContinuousRotationMotor
-from concert.devices.shutters.dummy import Shutter
-from concert.storage import RemoteDirectoryWalker
-from concert.networking.base import get_tango_device
-from concert.experiments.synchrotron import RemoteContinuousTomography
 from concert.devices.cameras.uca import RemoteNetCamera
-from concert.helpers import CommData
 from concert.tests import TestCase
-####################################################################################################
-# Docker daemon creates a DNS entries inside the specified network with the service names. We need
-# to specify these domain names to communicate with a services on a given exposed port. In the
-# compose.yml we have specified `uca_camera` and `remote_walker` as service names for the mock
-# camera and walker tango server processes running inside their respective containers. Hence, in the
-# session we'd have to use these domain names. Moreover, we will use the environment variables,
-# which were injected to conainer process. These environment variables encapsulate relevant metadata
-# from container orchestration, which are necessary to write the test cases.
-####################################################################################################
+from abc import ABC, abstractmethod
 
 
-class TestRemoteExperiment(TestCase):
+class TestExperimentBase(TestCase, ABC):
+    """Base class for experiment tests with common functionality."""
 
     @staticmethod
     def list_files(startpath: str) -> None:
+        """List all files in a directory tree."""
         for root, dirs, files in os.walk(startpath):
             level: str = root.replace(startpath, '').count(os.sep)
             indent: str = ' ' * 4 * (level)
@@ -45,48 +30,35 @@ class TestRemoteExperiment(TestCase):
                 print('{}{}'.format(subindent, f))
 
     async def asyncSetUp(self) -> None:
+        """Set up the experiment with common configuration."""
         await super().asyncSetUp()
-        walker_host = os.environ["REMOTE_WALKER_HOST"]
-        walker_port = os.environ["REMOTE_WALKER_PORT"]
-        walker_dn = os.environ["REMOTE_WALKER_DN"]
-        self._walker_dev_uri = f"{walker_host}:{walker_port}/{walker_dn}#dbase=no"
         self._num_darks = 10
         self._num_flats = 10
         self._num_radios = 100
-        self._servers = {
-            "walker": CommData(
-                os.environ["UCA_NET_HOST"],
-                port=os.environ["UCA_WALKER_ZMQ_PORT"],
-                socket_type=zmq.PUSH
-            )
-        }
         self._camera = await RemoteNetCamera()
         if await self._camera.get_state() == 'recording':
             await self._camera.stop_recording()
         self._root = os.environ["DATA_ROOT"]
-        self._walker = await RemoteDirectoryWalker(
-            device=get_tango_device(self._walker_dev_uri, timeout=30 * 60 * q.s),
-            root=self._root,
-            bytes_per_file=2 ** 40)
-        shutter = await Shutter()
-        flat_motor = await LinearMotor()
-        tomo = await ContinuousRotationMotor()
-        self._exp = await RemoteContinuousTomography(
-            walker=self._walker,
-            flat_motor=flat_motor,
-            tomography_motor=tomo,
-            radio_position=0 * q.mm,
-            flat_position=10 * q.mm,
-            camera=self._camera,
-            shutter=shutter,
-            num_flats=self._num_flats,
-            num_darks=self._num_darks,
-            num_projections=self._num_radios
-        )
-        _ = await tango_addons.ImageWriter(self._exp, self._servers["walker"],
-                                           self._exp.acquisitions)
-        # Run some cleanups in the mounted location before running the
-        # experiment.
+        
+        # Setup experiment-specific components
+        await self._setup_walker()
+        await self._setup_experiment()
+        
+        # Clean up any existing scan data
+        self._clean_scan_data()
+
+    @abstractmethod
+    async def _setup_walker(self):
+        """Set up the directory walker - to be implemented by subclasses."""
+        ...
+
+    @abstractmethod
+    async def _setup_experiment(self):
+        """Set up the experiment - to be implemented by subclasses. Must create self._exp."""
+        ...
+
+    def _clean_scan_data(self):
+        """Clean up any existing scan data."""
         base_path: Path = Path(self._root)
         items: List[str] = os.listdir(base_path)
         items = list(filter(lambda name: "scan" in name, items))
@@ -99,6 +71,7 @@ class TestRemoteExperiment(TestCase):
                     shutil.rmtree(abs_path)
 
     async def test_run(self) -> None:
+        """Test running the experiment."""
         _ = await self._exp.run()
         base_path: Path = Path(self._root)
         items: List[str] = os.listdir(base_path)
@@ -132,19 +105,8 @@ class TestRemoteExperiment(TestCase):
                 self.assertTrue(len(radios) == int(exp_log["num_projections"]))
 
     async def asyncTearDown(self) -> None:
+        """Clean up after the test."""
         await super().asyncTearDown()
-        base_path: Path = Path(self._root)
-        items: List[str] = os.listdir(base_path)
-        items = list(filter(lambda name: "scan" in name, items))
-        if len(items) > 0:
-            for item in items:
-                abs_path: Path = base_path.joinpath(item)
-                if os.path.isfile(abs_path):
-                    os.remove(abs_path)
-                else:
-                    shutil.rmtree(abs_path)
-        await self._camera.unregister_all()
-
-
-if __name__ == "__main__":
-    pass
+        self._clean_scan_data()
+        if hasattr(self, '_camera'):
+            await self._camera.unregister_all()

--- a/concert/tests/integration/scenarios/test_local_experiment.py
+++ b/concert/tests/integration/scenarios/test_local_experiment.py
@@ -1,0 +1,45 @@
+"""
+test_local_experiment.py
+------------------
+Encapsulates local experiment test cases
+"""
+from concert.experiments.addons import local as local_addons
+from concert.quantities import q
+from concert.devices.motors.dummy import LinearMotor, ContinuousRotationMotor
+from concert.devices.shutters.dummy import Shutter
+from concert.storage import DirectoryWalker
+from concert.experiments.synchrotron import LocalContinuousTomography
+from concert.tests.integration.scenarios.test_experiment import TestExperimentBase
+
+
+class TestLocalExperiment(TestExperimentBase):
+    """Local experiment test case."""
+
+    async def _setup_walker(self):
+        """Set up the local directory walker."""
+        self._walker = await DirectoryWalker(
+            root=self._root,
+            bytes_per_file=2 ** 40)
+
+    async def _setup_experiment(self):
+        """Set up the local experiment."""
+        shutter = await Shutter()
+        flat_motor = await LinearMotor()
+        tomo = await ContinuousRotationMotor()
+        self._exp = await LocalContinuousTomography(
+            walker=self._walker,
+            flat_motor=flat_motor,
+            tomography_motor=tomo,
+            radio_position=0 * q.mm,
+            flat_position=10 * q.mm,
+            camera=self._camera,
+            shutter=shutter,
+            num_flats=self._num_flats,
+            num_darks=self._num_darks,
+            num_projections=self._num_radios
+        )
+        _ = await local_addons.ImageWriter(self._exp)
+
+
+if __name__ == "__main__":
+    pass

--- a/concert/tests/integration/scenarios/test_remote_experiment.py
+++ b/concert/tests/integration/scenarios/test_remote_experiment.py
@@ -1,0 +1,77 @@
+"""
+test_remote_experiment.py
+------------------
+Encapsulates remote experiment test cases
+"""
+import os
+import zmq
+from concert.experiments.addons import tango as tango_addons
+from concert.quantities import q
+from concert.devices.motors.dummy import LinearMotor, ContinuousRotationMotor
+from concert.devices.shutters.dummy import Shutter
+from concert.storage import RemoteDirectoryWalker
+from concert.networking.base import get_tango_device
+from concert.experiments.synchrotron import RemoteContinuousTomography
+from concert.helpers import CommData
+from concert.tests.integration.scenarios.test_experiment import TestExperimentBase
+
+####################################################################################################
+# Docker daemon creates DNS entries inside the specified network with the service names.
+# We need to specify these domain names to communicate with services on a given exposed port.
+# In the compose.yml we have specified `uca_camera` and `remote_walker` as service names for the mock
+# camera and walker tango server processes running inside their respective containers.
+# Hence, in the session we'd have to use these domain names.
+# Moreover, we will use the environment variables, which were injected to container processes.
+# These environment variables encapsulate relevant metadata from container orchestration,
+# which is necessary to write the test cases.
+####################################################################################################
+
+
+class TestRemoteExperiment(TestExperimentBase):
+    """Remote experiment test case."""
+
+    async def asyncSetUp(self) -> None:
+        # Set up remote-specific configuration
+        walker_host = os.environ["REMOTE_WALKER_HOST"]
+        walker_port = os.environ["REMOTE_WALKER_PORT"]
+        walker_dn = os.environ["REMOTE_WALKER_DN"]
+        self._walker_dev_uri = f"{walker_host}:{walker_port}/{walker_dn}#dbase=no"
+        self._servers = {
+            "walker": CommData(
+                os.environ["UCA_NET_HOST"],
+                port=os.environ["UCA_WALKER_ZMQ_PORT"],
+                socket_type=zmq.PUSH
+            )
+        }
+        await super().asyncSetUp()
+
+    async def _setup_walker(self):
+        """Set up the remote directory walker."""
+        self._walker = await RemoteDirectoryWalker(
+            device=get_tango_device(self._walker_dev_uri, timeout=30 * 60 * q.s),
+            root=self._root,
+            bytes_per_file=2 ** 40)
+
+    async def _setup_experiment(self):
+        """Set up the remote experiment."""
+        shutter = await Shutter()
+        flat_motor = await LinearMotor()
+        tomo = await ContinuousRotationMotor()
+        self._exp = await RemoteContinuousTomography(
+            walker=self._walker,
+            flat_motor=flat_motor,
+            tomography_motor=tomo,
+            radio_position=0 * q.mm,
+            flat_position=10 * q.mm,
+            camera=self._camera,
+            shutter=shutter,
+            num_flats=self._num_flats,
+            num_darks=self._num_darks,
+            num_projections=self._num_radios
+        )
+        _ = await tango_addons.ImageWriter(self._exp, self._servers["walker"],
+                                           self._exp.acquisitions)
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
The base camera and the uca-camera were both trying to acquire the grab_lock, which resulted in a deadlock.
Also, a scenario-integration test with a local experiment and a libuca-camera was added.