### PR TITLE
feature: Online rotation axis estimation

### DIFF
--- a/concert/ext/cmd/tango.py
+++ b/concert/ext/cmd/tango.py
@@ -1,6 +1,6 @@
 from concert.session.utils import setup_logging, SubCommand
 
-SERVER_NAMES = ['benchmarker', 'reco', 'walker']
+SERVER_NAMES = ['benchmarker', 'reco', 'walker', 'rae']
 
 
 class TangoCommand(SubCommand):
@@ -58,6 +58,9 @@ class TangoCommand(SubCommand):
         if server == "walker":
             from concert.ext.tangoservers import walker
             server_class = {'class': walker.TangoRemoteWalker}
+        if server == "rae":
+            from concert.ext.tangoservers import rae
+            server_class = {'class': rae.TangoRotationAxisEstimator}
 
         setup_logging(server, to_stream=True, filename=logfile, loglevel=loglevel)
 

--- a/concert/ext/tangoservers/bin/TangoRotationAxisEstimator
+++ b/concert/ext/tangoservers/bin/TangoRotationAxisEstimator
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from concert.ext.tangoservers.rae import TangoRotationAxisEstimator
+from tango import GreenMode
+
+if __name__ == '__main__':
+    TangoRotationAxisEstimator.run_server(green_mode=GreenMode.Asyncio)

--- a/concert/ext/tangoservers/rae.py
+++ b/concert/ext/tangoservers/rae.py
@@ -1,0 +1,235 @@
+"""
+rae.py
+-----
+Implements a device server to execute rotation axis estimation routines during acquisition.
+"""
+from typing import List, AsyncIterator
+import numpy as np
+import scipy.optimize as sop
+from tango import DebugIt
+from tango.server import attribute, command, AttrWriteType
+from concert.ext.tangoservers.base import TangoRemoteProcessing
+from concert.ext.ufo import FlatCorrect
+from concert.imageprocessing import get_sphere_absorption_pattern, get_sphere_center_corr
+from concert.typing import ArrayLike
+
+
+class TangoRotationAxisEstimator(TangoRemoteProcessing):
+    """
+    Implements Tango device server to estimate axis of rotation.
+    """
+    rot_angle = attribute(
+        label="Overall angle of rotation",
+        dtype=float,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_rot_angle",
+        fset="set_rot_angle",
+        doc="overall angle of rotation for current acquisition"
+    )
+
+    attr_acq = attribute(
+        label="Meta attribute for acquisition",
+        dtype=(int,),
+        max_dim_x=3,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_attr_acq",
+        fset="set_attr_acq",
+        doc="encapsulates acquisition meta information i.e., #darks, #flats, #radios"
+    )
+
+    axis_of_rotation = attribute(
+        label="Axis of rotation",
+        dtype=float,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_axis_of_rotation",
+        fset="set_axis_of_rotation",
+        doc="axis of rotation to be estimated from incoming projections"
+    )
+
+    attr_track = attribute(
+        label="Meta attributes for marker tracking",
+        dtype=(int,),
+        max_dim_x=4,
+        access=AttrWriteType.WRITE,
+        fset="set_attr_track",
+        doc="encapsulates meta attributes for marker tracking i.e. \
+        crop_vert_prop, \
+        crop_left_px, \
+        crop_right_px, \
+        radius"
+    )
+
+    attr_estm = attribute(
+        label="Meta attributes for axis estimation",
+        dtype=(float,),
+        max_dim_x=4,
+        access=AttrWriteType.WRITE,
+        fset="set_attr_estm",
+        doc="encapsulates attributes for axis estimation.e., \
+        init_wait, \
+        avg_beta, \
+        diff_thresh, \
+        conv_window"
+    )
+
+    async def init_device(self) -> None:
+        await super().init_device()
+        # We initialize axis_of_rotation attribute with None as a safeguard against mis-fire of the
+        # tango events. Reco device should only take a non-None value of axis of rotation into
+        # account.
+        self._axis_of_rotation = None
+        self.set_change_event("axis_of_rotation", True, False)
+        self.info_stream("%s initialized device with state: %s", self.__class__.__name__,
+                         self.get_state())
+
+    def get_rot_angle(self) -> float:
+        return self._rot_angle
+
+    def set_rot_angle(self, rot_angle: float) -> None:
+        self._rot_angle = rot_angle
+        self.info_stream(
+            "%s has set angle of rotation to: %f", self.__class__.__name__, self._rot_angle)
+
+    def get_attr_acq(self) -> ArrayLike:
+        return self._attr_acq
+
+    def set_attr_acq(self, aa: ArrayLike) -> None:
+        self._attr_acq = aa
+
+    def get_axis_of_rotation(self) -> float:
+        return self._axis_of_rotation
+
+    def set_axis_of_rotation(self, new_value: float) -> None:
+        self._axis_of_rotation = new_value
+
+    def set_attr_track(self, at: ArrayLike) -> None:
+        self._attr_track = at
+
+    def set_attr_estm(self, ae: ArrayLike) -> None:
+        self._attr_estm = ae
+
+    async def _process_flat_fields(self, name: str, producer: AsyncIterator[ArrayLike]) -> None:
+        """
+        Accumulates dark and flat fields, average them and store as dynamic class members, _dark,
+        _flat
+        """
+        num_proj = 0
+        buffer: List[ArrayLike] = []
+        async for projection in producer:
+            buffer.append(projection)
+            num_proj += 1
+        setattr(self, name, np.array(buffer).mean(axis=0))
+        self.info_stream("%s: processed %d %s projections", self.__class__.__name__, num_proj,
+                         name[1:])
+
+    @DebugIt()
+    @command()
+    async def update_darks(self) -> None:
+        await self._process_stream(self._process_flat_fields("_dark", self._receiver.subscribe()))
+
+    @DebugIt()
+    @command()
+    async def update_flats(self) -> None:
+        await self._process_stream(self._process_flat_fields("_flat", self._receiver.subscribe()))
+
+    @DebugIt()
+    @command()
+    async def estimate_axis_of_rotation(self) -> None:
+        """Estimates the center of rotation"""
+        _, _, num_radios = self._attr_acq
+        _, _, _, radius = self._attr_track
+        self._angles = np.linspace(0., self._rot_angle, num_radios)
+        self._sphere = get_sphere_absorption_pattern(radius=radius)
+        self.info_stream("%s: starting estimation", self.__class__.__name__)
+        await self._process_stream(self._track_spheres(self._receiver.subscribe()))
+
+    @staticmethod
+    def _opt_func(angle_x: float, center_p1: float, radius_p2: float, phase_p3: float) -> float:
+        """Defines the optimization function"""
+        return center_p1 + radius_p2 * np.cos(angle_x + phase_p3)
+
+    async def _track_spheres(self, producer: AsyncIterator[ArrayLike]) -> None:
+        """
+        Estimates the center of rotation with marker tracking and nonlinear polynomial fit.
+        :param: producer: asynchronous generator of projections.
+        :type producer: AsyncIterator[ArrayLike]
+        """
+        crop_vert_prop, crop_left_px, crop_right_px, radius = self._attr_track
+        init_wait, avg_beta, diff_thresh, conv_window = self._attr_estm
+        init_wait, conv_window = int(init_wait), int(conv_window)
+        proj_count = 0
+        centers: List[List[int]] = []
+        ffc = FlatCorrect(dark=self._dark, flat=self._flat, absorptivity=True)
+        est_axes: List[float] = []
+        converged: bool = False
+        try:
+            async for proj in ffc(producer):
+                yc, xc = get_sphere_center_corr(proj=proj, sphere=self._sphere, radius=radius,
+                                                crop_vert_prop=crop_vert_prop,
+                                                crop_left_px=crop_left_px,
+                                                crop_right_px=crop_right_px)
+                centers.append([yc, xc])
+                if proj_count > init_wait:
+                    x: ArrayLike = self._angles[:proj_count]
+                    y: ArrayLike = np.array(centers)[:proj_count, 1]
+                    params, _ = sop.curve_fit(f=self._opt_func, xdata=np.squeeze(x),
+                                              ydata=np.squeeze(y))
+                    est_axis: float = crop_left_px + params[0]
+                    if len(est_axes) == 0:
+                        est_axes.append(np.round(est_axis, decimals=1))
+                    else:
+                        avg_est: float = (avg_beta * est_axes[-1]) + ((1 - avg_beta) * est_axis)
+                        avg_est /= (1 - avg_beta**proj_count)
+                        est_axes.append(np.round(avg_est, decimals=1))
+                    self.info_stream("%s: current estimation: %.1f", self.__class__.__name__,
+                                     est_axes[-1])
+                # Convergence: check if we have landed on a stable value. This check happens for
+                # each projection after given number of estimations are available. Since we want to
+                # achieve less than half-pixel error in estimation, we round the estimated values
+                # to 1 decimal position and compare against a threshold value, which should be less
+                # than configured diff_thresh.
+                if not converged and len(est_axes) > conv_window:
+                    if proj_count % 10 == 0:
+                        self.debug_stream(
+                                "estimation diff: %s",
+                                np.round(np.abs(np.diff(est_axes[-conv_window:])), decimals=1))
+                    if np.all(np.round(np.abs(np.diff(est_axes[-conv_window:])),
+                                       decimals=1) < diff_thresh):
+                        self._axis_of_rotation = est_axes[-1]
+                        self.info_stream("%s: converged at: %.1f", self.__class__.__name__,
+                                         self._axis_of_rotation)
+                        self.push_change_event("axis_of_rotation", self._axis_of_rotation)
+                        converged = True
+                        break
+                proj_count += 1
+            # If not converged final estimate is used to carry out the reconstruction.
+            if not converged:
+                self._axis_of_rotation = est_axes[-1]
+                self.info_stream("%s: final estimate: %.1f", self.__class__.__name__,
+                                 self._axis_of_rotation)
+                self.push_change_event("axis_of_rotation", self._axis_of_rotation)
+        except Exception as e:
+            self.info_stream("%s: runtime error: %s, unblocking reco with generic value",
+                             self.__class__.__name__, str(e))
+            # Unblock reco device server if the axis estimation routine is not successful for some
+            # reason. In that case we take half of the projection width as a generic value.
+            self._axis_of_rotation = proj.shape[1] / 2
+            self.push_change_event("axis_of_rotation", self._axis_of_rotation)
+        # Set axis_of_rotation attribute back to None to safe-guard against mis-fire of tango
+        # events.
+        self._axis_of_rotation = None
+        try:
+            # NOTE: We need to put this strategy into test. Since this routine is supposed to be
+            # executed in the reconstruction server its implication on the reconstruction workflow
+            # needs to be understood.
+            import cupy as cp
+            cp._default_memory_pool.free_all_blocks()
+            self.info_stream("%s: attempted to release unused GPU memory")
+        except ModuleNotFoundError:
+            # If cupy is available we ensure to release all allocated GPU memory for current
+            # stream. We don't need to do anything specific otherwise.
+            pass
+
+
+if __name__ == "__main__":
+    pass

--- a/concert/ext/tangoservers/reco.py
+++ b/concert/ext/tangoservers/reco.py
@@ -1,18 +1,16 @@
 """Tango device for online 3D reconstruction from zmq image stream."""
 import asyncio
-from enum import IntEnum
-import os
-from typing import Tuple, Optional
+from typing import Optional
 import numpy as np
 from tango import DebugIt, CmdArgType, PipeWriteType, EventType, EventData
 from tango.server import command, pipe
-from tango.asyncio import DeviceProxy
 from .base import TangoRemoteProcessing
 from concert.coroutines.base import async_generate
 from concert.ext.ufo import GeneralBackprojectManager, LocalGeneralBackprojectArgs
 from concert.quantities import q
 from concert.networking.base import get_tango_device, ZmqSender
 from concert.storage import RemoteDirectoryWalker
+from concert.typing import AbstractRAEDevice
 from ...config import DISTRIBUTED_TANGO_TIMEOUT
 
 MAX_DIM = 100000
@@ -51,16 +49,6 @@ async def set_{0}(self, values):
     except TypeError:
         await self._args.set_reco_arg("{0}", values)
 """
-
-
-class OpMode(IntEnum):
-    """
-    Mode of operation for online reconstruction. It can be either standalone, in which it expects
-    axis of rotation would be provided manually. Alternatively, it can subscribe for an event from
-    rotation axis estimator device server for axis of rotation.
-    """
-    STANDALONE = 0
-    RAE_DEPENDENT = 1
 
 
 class TangoOnlineReconstruction(TangoRemoteProcessing):
@@ -109,9 +97,7 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
         access=PipeWriteType.PIPE_READ_WRITE
     )
 
-    op_mode = attribute(dtype=OpMode, access=AttrWriteType.READ_WRITE)
-
-    _rae_device: Optional[DeviceProxy]
+    _rae_device: Optional[AbstractRAEDevice]
     _rae_subscription: Optional[int]
     _axis_estmd: Optional[asyncio.Event]
     _manager: GeneralBackprojectManager
@@ -120,7 +106,7 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
         """Inits device and communciation"""
         await super().init_device()
         # By default online reconstruction is decoupled from rotation axis estimator
-        self._op_mode = OpMode(0)
+        self._axis_estmd = None
         self._manager = await GeneralBackprojectManager(
             self._args,
             average_normalization=True
@@ -128,40 +114,25 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
         self._walker = None
         self._sender = None
         self._find_args = None
-        self.info_stream("%s: %s with default operation mode: STANDALONE", self.__class__.__name__,
-                         self.get_state())
-
-    def read_op_mode(self) -> OpMode:
-        return self._op_mode
-
-    def write_op_mode(self, om: OpMode) -> None:
-        self._op_mode = om
-        if self._op_mode == OpMode.RAE_DEPENDENT:
-            self._axis_estmd = asyncio.Event()
-            self._manager.set_axis_estmd(self._axis_estmd)
-        self.info_stream("%s: set operation mode to: %s", self.__class__.__name__,
-                         "RAE_DEPENDENT" if self._op_mode == OpMode.RAE_DEPENDENT else "STANDALONE")
 
     @DebugIt()
     @command(
-        dtype_in=(str,),
-        doc_in="port and domain namespace for rotation axis estimator device"
+        dtype_in=str,
+        doc_in="device proxy uri for rotation axis estimator tango device"
     )
-    async def register_rotation_axis_feedback(self, args: Tuple[str, str]) -> None:
+    async def register_axis_feedback(self, rae_dev_uri: str) -> None:
         """
         Subscribes for event concerning axis of rotation estimation.
         Arguments include port number and domain namespace for rotation axis estimator device.
         """
-        if self._op_mode == OpMode.RAE_DEPENDENT:
-            # Get the device proxy reference for RotationAxisEstimator device and subscribe for event
-            rae_dev_ref = f"{os.uname()[1]}:{args[0]}/{args[1]}#dbase=no"
-            self._rae_device = get_tango_device(rae_dev_ref, timeout=1000 * q.s)
-            self._rae_subscription = await self._rae_device.subscribe_event(
-                    "axis_of_rotation", EventType.CHANGE_EVENT, self._on_axis_of_rotation)
-            self.info_stream("%s: registered rotation axis feedback", self.__class__.__name__)
-        else:
-            self.info_stream("%s: cannot register rotation axis feedback on standalone mode.",
-                             self.__class__.__name__)
+        # Get the device proxy reference for RotationAxisEstimator device and subscribe for event.
+        self._axis_estmd = asyncio.Event()
+        self._manager.set_axis_estmd(self._axis_estmd)
+        self._rae_device = get_tango_device(rae_dev_uri, timeout=1000 * q.s)
+        self._rae_subscription = await self._rae_device.subscribe_event(
+                "axis_of_rotation", EventType.CHANGE_EVENT, self._on_axis_of_rotation)
+        self.info_stream("%s: registered rotation axis feedback from: %s",
+                         self.__class__.__name__, rae_dev_uri)
 
     def _on_axis_of_rotation(self, event: EventData) -> None:
         """
@@ -247,7 +218,7 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
     async def reconstruct(self, slice_directory):
         await self._reconstruct(cached=False, slice_directory=slice_directory)
         # If relevant, enable waiting for estimated axis of rotation on next reconstruction
-        if self._op_mode == OpMode.RAE_DEPENDENT and self._axis_estmd is not None:
+        if self._axis_estmd is not None:
             self._axis_estmd.clear()
 
     @DebugIt(show_args=True)

--- a/concert/typing.py
+++ b/concert/typing.py
@@ -136,7 +136,24 @@ class RemoteDirectoryWalkerTangoDevice(
         consists of log path as identifier for logger, logging level and log message.
         """
         ...
-#####################################################################
+
+
+class AbstractRAEDevice(Protocol):
+    """
+    Abstract rotation axis estimator device type.
+    """
+
+    async def update_darks(self) -> None:
+        """Accumulates the dark field projections"""
+        ...
+
+    async def update_flats(self) -> None:
+        """Accumulates the flat field projections"""
+        ...
+
+    async def estimate_axis_of_rotation(self) -> None:
+        """Executes axis of rotation estimation from radiogram projections"""
+        ...
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
              'concert/ext/tangoservers/bin/TangoOnlineReconstruction',
              'concert/ext/tangoservers/bin/TangoRemoteWalker',
              'concert/ext/tangoservers/bin/TangoBenchmarker',
+             'concert/ext/tangoservers/bin/TangoRotationAxisEstimator',
              'concert/ext/tangoservers/bin/run_server_detached'],
     data_files=data_files,
     exclude_package_data={'': ['README.rst']},


### PR DESCRIPTION
**Premise**: This PR proposes an online rotation axis estimation implementation, which can be used with online reconstruction as an optional add-on. Following snippets conceptually demonstrates the usage pattern for the same. In first scenario reco device server operates in standalone mode and we need to explicitly provide correct axis of rotation. In second scenario we provide an instance of the rotation of axis estimator addon as an optional parameter, in which case reco device server internally subscribes for an event from the RAE device server and waits until an axis value is estimated before starting the reconstruction. In this scenario no explicitly `center_position_x` parameter is necessary.

```python
reco_device = get_tango_device(reco_dev_uri, timeout=...)
reco = await tango_addons.OnlineReconstruction(reco_device, experiment, endpoint)
await reco.set_center_position_x([...] * q.px)
```
```python
rae_device = get_tango_device(uri=rae_dev_uri, timeout=...)
rae = await tango_addons.RotationAxisEstimator(device=rae_device, args...)
reco_device = get_tango_device(reco_dev_uri, timeout=...)
reco = await tango_addons.OnlineReconstruction(reco_device, experiment, endpoint, use_rae=rae)
```