### PR TITLE
experimental: Implement self fourier shell correlation

### DIFF
--- a/concert/ext/cmd/tango.py
+++ b/concert/ext/cmd/tango.py
@@ -1,6 +1,6 @@
 from concert.session.utils import setup_logging, SubCommand
 
-SERVER_NAMES = ['benchmarker', 'reco', 'walker']
+SERVER_NAMES = ['benchmarker', 'reco', 'walker', 'porqa']
 
 
 class TangoCommand(SubCommand):
@@ -58,6 +58,9 @@ class TangoCommand(SubCommand):
         if server == "walker":
             from concert.ext.tangoservers import walker
             server_class = {'class': walker.TangoRemoteWalker}
+        if server == "porqa":
+            from concert.ext.tangoservers import porqa
+            server_class = {'class': porqa.TangoPostReconstructionQA}
 
         setup_logging(server, to_stream=True, filename=logfile, loglevel=loglevel)
 

--- a/concert/ext/tangoservers/porqa.py
+++ b/concert/ext/tangoservers/porqa.py
@@ -1,0 +1,141 @@
+"""
+porqa.py
+---------
+Implements a device server to execute post-reconstruction quality assurance routines.
+"""
+import logging
+from typing import AsyncIterator, List
+import numpy as np
+import matplotlib.pyplot as plt
+try:
+    import cupy as xp
+    import cupy.fft as xft
+except ModuleNotFoundError:
+    print("cupy not available, defaulting to numpy")
+    import numpy as xp
+    import numpy.fft as xft
+from tango import DebugIt, DevState
+from tango.server import attribute, AttrWriteType, command
+from tqdm import tqdm
+from concert.ext.tangoservers.base import TangoRemoteProcessing
+from concert.typing import ArrayLike
+
+
+class TangoPostReconstructionQA(TangoRemoteProcessing):
+    """Tango device for post-reconstruction quality assurance on a remote server"""
+
+    freq_bins = attribute(
+        label="Number of frequency bins",
+        dtype=int,
+        access=AttrWriteType.WRITE,
+        fget="get_freq_bins",
+        fset="set_freq_bins",
+        doc="number of frequency bins for Fourier Shell Correlation (FSC) calculation"
+    )
+
+    plot = attribute(
+        label="Plot",
+        dtype=bool,
+        access=AttrWriteType.WRITE,
+        fget="get_plot",
+        fset="set_plot",
+        doc="Plot of the Fourier Shell Correlation (FSC) in different directions"
+    )
+
+    async def init_device(self) -> None:
+        """
+        Initializes the remote walker tango device. Sets the remote server's
+        home directory as root as well as the current directory.
+        """
+        logging.getLogger('matplotlib.font_manager').disabled = True
+        await super().init_device()
+        self.set_state(DevState.STANDBY)
+        self.info_stream(
+            "%s in state: %s", self.__class__.__name__, self.get_state())
+        
+    def get_freq_bins(self) -> int:
+        return self._freq_bins
+    
+    def set_freq_bins(self, fb: int) -> None:
+        self._freq_bins = fb
+        self.info_stream("%s: set frequency bins to %d", self.__class__.__name__, fb)
+
+    def get_plot(self) -> bool:
+        return self._plot
+    
+    def set_plot(self, plot: bool) -> None:
+        self._plot = plot
+        self.info_stream("%s: set plot to %s", self.__class__.__name__, plot)
+
+    @DebugIt(show_args=True)
+    @command()
+    async def exec_qa(self) -> None:
+        await self._process_stream(self._exec_fsc(self._receiver.subscribe()))
+
+    def _compute_directional_fsc(self, fft1: ArrayLike, fft2: ArrayLike,
+                                 direction: str = 'xy') -> ArrayLike:
+        self.info_stream("%s: computing SFSC for direction %s", self.__class__.__name__, direction)
+        z, y, x = np.indices(fft1.shape)
+        center: ArrayLike = np.array(fft2.shape) // 2
+        rz, ry, rx = z - center[0], y - center[1], x - center[2]
+        # Directional distance
+        if direction == 'xy':
+            r: float = np.sqrt(rx**2 + ry**2)
+        elif direction == 'yz':
+            r: float = np.sqrt(ry**2 + rz**2)
+        elif direction == 'zx':
+            r: float = np.sqrt(rz**2 + rx**2)
+        else:
+            raise ValueError("Invalid direction")
+        r = r.astype(int)
+        fsc_num: ArrayLike = np.zeros(self._freq_bins)
+        fsc_den1: ArrayLike = np.zeros(self._freq_bins)
+        fsc_den2: ArrayLike = np.zeros(self._freq_bins)
+        for i in tqdm(range(self._freq_bins), total=self._freq_bins):
+            mask = (r == i)
+            fft1_shell = fft1[mask]
+            fft2_shell = fft2[mask]
+            if len(fft1_shell) > 0:
+                fsc_num[i] = np.sum(fft1_shell * np.conj(fft2_shell)).real
+                fsc_den1[i] = np.sum(np.abs(fft1_shell)**2)
+                fsc_den2[i] = np.sum(np.abs(fft2_shell)**2)
+        fsc: ArrayLike = fsc_num / (np.sqrt(fsc_den1 * fsc_den2) + 1e-8)
+        self.info_stream("%s: SFSC in %s direction : %s", self.__class__.__name__, direction, fsc)
+        return fsc
+
+    async def _exec_fsc(self, producer: AsyncIterator[ArrayLike]) -> None:
+        """Computes Self Fourier Shell Correlation (FSC) for reconstructed volume"""
+        slices: List[ArrayLike] = [slice async for slice in producer]
+        volume: ArrayLike = np.stack(slices, axis=0)
+        if volume.ndim != 3:
+            self.error_stream(
+                "%s: expected 3D volume, got %d", self.__class__.__name__, volume.ndim)
+            return
+        self.info_stream("%s: computing directional SFSC with %d frequency bins",
+                         self.__class__.__name__, self._freq_bins)
+        even_volume, odd_volume = volume[::2, :, :], volume[1::2, :, :]
+        min_z = min(even_volume.shape[0], odd_volume.shape[0])
+        even_volume, odd_volume = even_volume[:min_z], odd_volume[:min_z]
+        self.info_stream("%s: dtsributed volumes into even and odd slices having shape: %s",
+                         self.__class__.__name__, even_volume.shape)
+        xp._default_memory_pool.free_all_blocks()
+        # Compute Fourier transforms
+        even_fft: ArrayLike = xp.asnumpy(
+            xft.fftshift(xft.fftn(xp.asarray(even_volume.astype(np.float32)))))
+        odd_fft: ArrayLike = xp.asnumpy(
+            xft.fftshift(xft.fftn(xp.asarray(odd_volume.astype(np.float32)))))
+        xp._default_memory_pool.free_all_blocks()
+        fsc_xy: ArrayLike = self._compute_directional_fsc(even_fft, odd_fft, direction='xy')
+        fsc_yz: ArrayLike = self._compute_directional_fsc(even_fft, odd_fft, direction='yz')
+        fsc_zx: ArrayLike = self._compute_directional_fsc(even_fft, odd_fft, direction='zx')
+        if self._plot:
+            plt.figure()
+            plt.plot(np.arange(10) + 1, fsc_xy, "o-", color="#E45756", label="SFSC-XY");
+            plt.plot(np.arange(10) + 1, fsc_yz, "o-", color="#F58518", label="SFSC-YZ");
+            plt.plot(np.arange(10) + 1, fsc_zx, "o-", color="#009392", label="SFSC-ZX");
+            plt.legend()
+            plt.show()
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
**Premise**: This PR provides an experimental implementation for the Self Fourier Shell Correlation. Reconstruction device server streams the reconstructed slices to post reconstruction qa device server, which divides the slices into even and odd stacks and computes directional FSC.

Example session to use the new device server.

```python
import asyncio
import logging
import os
import numpy as np
import zmq
import concert
from concert.experiments.addons import tango as tango_addons
from concert.quantities import q
from concert.devices.motors.dummy import LinearMotor, ContinuousRotationMotor
from concert.devices.shutters.dummy import Shutter
from concert.storage import RemoteDirectoryWalker
from concert.ext.viewers import PyQtGraphViewer
from concert.networking.base import get_tango_device
from concert.experiments.synchrotron import RemoteContinuousTomography
from concert.devices.cameras.dummy import FileCamera
from concert.helpers import CommData

# Run Acquisitions Walker Writer: concert tango walker --loglevel perfdebug --port 7001
# Run RotationAxisEstimator Server: concert tango rae --loglevel perfdebug --port 7002
# Run OnlineReconstruction: concert tango reco --loglevel perfdebug --port 7003
# Run Walker for OnlineReconstruction: concert tango walker --loglevel perfdebug --port 7004
walker_dev_uri = f"{os.uname()[1]}:7001/concert/tango/walker#dbase=no"
rae_dev_uri = f"{os.uname()[1]}:7002/concert/tango/rae#dbase=no"
reco_dev_uri = f"{os.uname()[1]}:7003/concert/tango/reco#dbase=no"
remote_reco_walker_dev_uri = f"{os.uname()[1]}:7004/concert/tango/walker#dbase=no"
porqa_dev_uri = f"{os.uname()[1]}:7005/concert/tango/porqa#dbase=no"

# Communications Metadata
SERVERS = {
        "walker": CommData("localhost", port=8993, socket_type=zmq.PUSH),
        "live": CommData("localhost", port=8995, socket_type=zmq.PUB, sndhwm=1),
        "rae": CommData("localhost", port=8997, socket_type=zmq.PUSH),
        "reco": CommData("localhost", port=8999, socket_type=zmq.PUSH)
}

num_darks = 100
num_flats = 100
num_radios = 2000

# Camera
roi_height = 2160
roi_width = 2560
pattern = "/home/ws/nj4412/workspace/projects/data/measurements/hika/rae/camera/*.tif"
camera = await FileCamera(pattern=pattern, reset_on_start=False)
if await camera.get_state() == 'recording':
    await camera.stop_recording()
await camera.set_roi_width(roi_width * q.px)
await camera.set_roi_height(roi_height * q.px)

# Walker | Writer Configuration
root = "/home/ws/nj4412/workspace/projects/sink"
walker_device = get_tango_device(walker_dev_uri, timeout=30 * 60 * q.s)
walker = await RemoteDirectoryWalker(device=walker_device, root=root, bytes_per_file=2**40)

# Experiment Configuration
shutter = await Shutter()
flat_motor = await LinearMotor()
tomo = await ContinuousRotationMotor()
exp = await RemoteContinuousTomography(walker=walker,
                                       flat_motor=flat_motor, 
                                       tomography_motor=tomo,
                                       radio_position=0*q.mm,
                                       flat_position=10*q.mm,
                                       camera=camera,
                                       shutter=shutter,
                                       num_flats=num_flats,
                                       num_darks=num_darks,
                                       num_projections=num_radios)
_ = await tango_addons.ImageWriter(exp, SERVERS["walker"])

# Live View Configuration
viewer = await PyQtGraphViewer(show_refresh_rate=True)
_ = await tango_addons.LiveView(viewer, SERVERS["live"], exp)

# Online Reconstruction Configuration
reco_device = get_tango_device(reco_dev_uri, timeout=30 * 60 * q.s)
await reco_device.setup_walker([remote_reco_walker_dev_uri, root, "tcp", "localhost", "8996"])
# Register QA device
await reco_device.setup_qa([porqa_dev_uri, root, "tcp", "localhost", "8998"])
reco = await tango_addons.OnlineReconstruction(reco_device, exp, SERVERS["reco"])

# We set the center_position_z to the middle pixel in the vertical direction
await reco_device.write_attribute('center_position_z',
                                  [(await camera.get_roi_height()).magnitude / 2 + 0.5])
# We don't need to manually set the z-parameter because it is by default set to z, means region
# gives us the slices to be reconstructed.
# Test dataset rotation axis: 1493.1
await reco.set_center_position_x([1493.1] * q.px)
await reco.set_region([200, 250, 1])
await reco.set_fix_nan_and_inf(True)
await reco.set_absorptivity(True)
await reco_device.write_attribute('number', 2000)
await reco_device.write_attribute('overall_angle', np.pi)

# Post-Reconstruction QA
porqa_device = get_tango_device(porqa_dev_uri, timeout=30 * 60 * q.s)
await porqa_device.write_attribute('freq_bins', 10)  # Number of frequency beans
await porqa_device.write_attribute('plot', True)  # If directional FSC should be plotted.
porqa_device.exec_qa()
```