### PR TITLE
fix: Fix python in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apt install -y \
     python3-pip \
     python3-setuptools \
     python3-wheel \
-    python3-gi
+    python3-gi \
+    python-is-python3
 
 # Install necessary Python packages
 RUN pip install --break-system-packages \


### PR DESCRIPTION
**Premise**: Fix python in Dockerfile. Python2 headers are removed from Ubuntu 24.04. This causes build failures when older headers are being included while building libraries in Docker image.