### PR TITLE
Use property for getting enumerated values

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -134,10 +134,10 @@ class Camera(base.Camera):
 
         setattr(self.uca, 'enum_values', _Dummy())
 
-        def get_enum_bunch(enum):
+        def get_enum_bunch(prop):
             enum_map = {}
 
-            for key, value in list(enum.__enum_values__.items()):
+            for key, value in list(prop.__enum_values__.items()):
                 name = value.value_nick.upper().replace('-', '_')
                 enum_map[name] = key
 
@@ -146,7 +146,7 @@ class Camera(base.Camera):
         for prop in self.uca.props:
             if hasattr(prop, 'enum_class'):
                 setattr(self.uca.enum_values, prop.name.replace('-', '_'),
-                        get_enum_bunch(prop.default_value))
+                        get_enum_bunch(self.uca.get_property(prop.name)))
 
         self._uca_get_frame_rate = _new_getter_wrapper('frames-per-second')
         self._uca_set_frame_rate = _new_setter_wrapper('frames-per-second')


### PR DESCRIPTION
On one of the machines, conda had pygobject==3.50.0 installed and there the enumerated properties become `gi.repository.GObject.ParamSpecEnum` instead of `gobject.GParamSpec`. The `prop.default_value.__enum_values__` trick did not work anymore, because the `default_value` was an integer. This PR fixes it. However, I do now know if it will work on older versions of pygobject than 3.48.2 (which I tested). Code to reproduce:
```python
import gi
gi.require_version('Uca', '2.0')
from gi.repository import GObject, GLib, Uca
manager = Uca.PluginManager()
uca = manager.get_camerah("mock", None)
for prop in uca.props:
    if hasattr(prop, "enum_class"):
    eprop = prop
    break 
type(eprop)
gi.repository.GObject.ParamSpecEnum
```

Check before merge

- [x] HIKA PyGObject: 3.42.2
- [x] ID19 PyGObject: 3.48.2
- [ ] IMAGE PyGObject: 3.48.2
- [ ] CL/CT lab