### PR TITLE
Do not use asyncio in weakref.finalize

### DIFF
--- a/concert/devices/cameras/uca.py
+++ b/concert/devices/cameras/uca.py
@@ -303,7 +303,20 @@ async def _ucad_communicate(request, host, port):
 
 
 def _ucad_unregister_all(host, port):
-    asyncio.run(_ucad_communicate(struct.pack("I", 14), host, port))
+    import socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.connect((host, port))
+        sock.sendall(struct.pack("I", 14))
+        # 1024 is more than the reply message size of ucad, so no need to call multiple times
+        reply = sock.recv(1024)
+        _construct_ucad_error(reply)
+    except Exception as e:
+        LOG.error(e)
+        print(
+            "Unregistration of camera endpoints failed due "
+            "to connection failure, see concert log for more details."
+        )
     LOG.debug("Unregistered all endpoints on %s:%d", host, port)
 
 


### PR DESCRIPTION
because the ThreadPoolExecutor of asyncio streams complains about submitting things after interpreter shutdown. Instead of trying to be super-clever, I just use the standard sockets, which work and there is no magic. @MarcusZuber this is one of the reasons why async destructors would bite us in our asses in the future.

```python
Traceback (most recent call last):
  File "/usr/lib/python3.12/weakref.py", line 666, in _exitfunc
    f()
  File "/usr/lib/python3.12/weakref.py", line 590, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tomas/.local/lib/python3.12/site-packages/concert/devices/cameras/uca.py", line 306, in _ucad_unregister_all
    asyncio.run(_ucad_communicate(struct.pack("I", 14), host, port))
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/tomas/.local/lib/python3.12/site-packages/concert/devices/cameras/uca.py", line 295, in _ucad_communicate
    reader, writer = await asyncio.open_connection(host, port)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/streams.py", line 48, in open_connection
    transport, _ = await loop.create_connection(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 1080, in create_connection
    infos = await self._ensure_resolved(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 1456, in _ensure_resolved
    return await loop.getaddrinfo(host, port, family=family, type=type,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 901, in getaddrinfo
    return await self.run_in_executor(
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 863, in run_in_executor
    executor.submit(func, *args), loop=self)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/thread.py", line 172, in submit
    raise RuntimeError('cannot schedule new futures after '
RuntimeError: cannot schedule new futures after interpreter shutdown
```