### PR TITLE
First attempt for allowing acquisition consumers to have different endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     libgirepository-1.0-dev \
     ninja-build \
     libzmq5-dev \
+    libjson-c-dev \
     libjson-glib-dev \
     iputils-ping \
     iproute2 \

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -8,6 +8,7 @@ from concert.config import DISTRIBUTED_TANGO_TIMEOUT
 from concert.coroutines.base import background
 from concert.experiments.addons import base
 from concert.experiments.base import Consumer
+from concert.helpers import CommData
 from concert.quantities import q
 from typing import Awaitable
 
@@ -119,8 +120,9 @@ class TangoMixin:
 
     :param device: a Tango device proxy
     :param endpoints: a dictionary mapping acquisitions to their endpoints. The key is the name of the acquisition.
+        A single CommData object can also be provided to use the same endpoint for all acquisitions.
     """
-    async def __ainit__(self, device, endpoints: dict) -> Awaitable:
+    async def __ainit__(self, device, endpoints: dict | CommData) -> Awaitable:
         self._device = device
         self._device.set_timeout_millis(DISTRIBUTED_TANGO_TIMEOUT)
         self._endpoints = endpoints
@@ -138,9 +140,11 @@ class Benchmarker(TangoMixin, base.Benchmarker):
     def _make_consumers(self, acquisitions):
         consumers = {}
 
+        use_same_endpoint = type(self._endpoints) is CommData
+
         for acq in acquisitions:
             consumers[acq] = TangoConsumer(
-                self._device, self._endpoints[acq.name], self.start_timer, corofunc_args=(acq.name,)
+                self._device, self._endpoints if use_same_endpoint else self._endpoints[acq.name], self.start_timer, corofunc_args=(acq.name,)
             )
 
         return consumers
@@ -184,9 +188,11 @@ class ImageWriter(TangoMixin, base.ImageWriter):
 
             return write_sequence
 
+        use_same_endpoint = type(self._endpoints) is CommData
+
         for acq in acquisitions:
             consumers[acq] = TangoConsumer(
-                self._device, self._endpoints[acq.name], prepare_wrapper(acq.name)
+                self._device, self._endpoints if use_same_endpoint else self._endpoints[acq.name], prepare_wrapper(acq.name)
             )
 
         return consumers
@@ -207,8 +213,10 @@ class LiveView(base.LiveView):
         async def consume():
             pass
 
+        use_same_endpoint = type(self._endpoints) is CommData
+
         for acq in acquisitions:
-            consumers[acq] = LiveViewConsumer(self._viewer, self.endpoints[acq.name], consume)
+            consumers[acq] = LiveViewConsumer(self._viewer, self._endpoints if use_same_endpoint else  self.endpoints[acq.name], consume)
 
         return consumers
 
@@ -266,16 +274,19 @@ class OnlineReconstruction(TangoMixin, base.OnlineReconstruction):
         flats = base.get_acq_by_name(acquisitions, 'flats')
         radios = base.get_acq_by_name(acquisitions, 'radios')
 
+        use_same_endpoint = type(self._endpoints) is CommData
+
+
         if self._do_normalization:
             consumers[darks] = TangoConsumer(
-                self._device, self._endpoints[darks.name], self.update_darks
+                self._device, self._endpoints if use_same_endpoint else self._endpoints[darks.name], self.update_darks
             )
             consumers[flats] = TangoConsumer(
-                self._device, self._endpoints[flats.name], self.update_flats
+                self._device, self._endpoints if use_same_endpoint else self._endpoints[flats.name], self.update_flats
             )
 
         consumers[radios] = TangoConsumer(
-            self._device, self._endpoints[radios.name], self.reconstruct
+            self._device, self._endpoints if use_same_endpoint else self._endpoints[radios.name], self.reconstruct
         )
 
         return consumers

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -125,7 +125,7 @@ class TangoMixin:
     async def __ainit__(self, device, endpoints: dict | CommData) -> Awaitable:
         self._device = device
         self._device.set_timeout_millis(DISTRIBUTED_TANGO_TIMEOUT)
-        self._endpoints = endpoints
+        self.endpoints = endpoints
 
     async def _teardown(self):
         await self._device.disconnect_endpoint()
@@ -140,11 +140,11 @@ class Benchmarker(TangoMixin, base.Benchmarker):
     def _make_consumers(self, acquisitions):
         consumers = {}
 
-        use_same_endpoint = type(self._endpoints) is CommData
+        use_same_endpoint = type(self.endpoints) is CommData
 
         for acq in acquisitions:
             consumers[acq] = TangoConsumer(
-                self._device, self._endpoints if use_same_endpoint else self._endpoints[acq.name], self.start_timer, corofunc_args=(acq.name,)
+                self._device, self.endpoints if use_same_endpoint else self.endpoints[acq.name], self.start_timer, corofunc_args=(acq.name,)
             )
 
         return consumers
@@ -188,11 +188,11 @@ class ImageWriter(TangoMixin, base.ImageWriter):
 
             return write_sequence
 
-        use_same_endpoint = type(self._endpoints) is CommData
+        use_same_endpoint = type(self.endpoints) is CommData
 
         for acq in acquisitions:
             consumers[acq] = TangoConsumer(
-                self._device, self._endpoints if use_same_endpoint else self._endpoints[acq.name], prepare_wrapper(acq.name)
+                self._device, self.endpoints if use_same_endpoint else self.endpoints[acq.name], prepare_wrapper(acq.name)
             )
 
         return consumers
@@ -213,10 +213,10 @@ class LiveView(base.LiveView):
         async def consume():
             pass
 
-        use_same_endpoint = type(self._endpoints) is CommData
+        use_same_endpoint = type(self.endpoints) is CommData
 
         for acq in acquisitions:
-            consumers[acq] = LiveViewConsumer(self._viewer, self._endpoints if use_same_endpoint else  self.endpoints[acq.name], consume)
+            consumers[acq] = LiveViewConsumer(self._viewer, self.endpoints if use_same_endpoint else  self.endpoints[acq.name], consume)
 
         return consumers
 
@@ -274,19 +274,19 @@ class OnlineReconstruction(TangoMixin, base.OnlineReconstruction):
         flats = base.get_acq_by_name(acquisitions, 'flats')
         radios = base.get_acq_by_name(acquisitions, 'radios')
 
-        use_same_endpoint = type(self._endpoints) is CommData
+        use_same_endpoint = type(self.endpoints) is CommData
 
 
         if self._do_normalization:
             consumers[darks] = TangoConsumer(
-                self._device, self._endpoints if use_same_endpoint else self._endpoints[darks.name], self.update_darks
+                self._device, self.endpoints if use_same_endpoint else self.endpoints[darks.name], self.update_darks
             )
             consumers[flats] = TangoConsumer(
-                self._device, self._endpoints if use_same_endpoint else self._endpoints[flats.name], self.update_flats
+                self._device, self.endpoints if use_same_endpoint else self.endpoints[flats.name], self.update_flats
             )
 
         consumers[radios] = TangoConsumer(
-            self._device, self._endpoints if use_same_endpoint else self._endpoints[radios.name], self.reconstruct
+            self._device, self.endpoints if use_same_endpoint else self.endpoints[radios.name], self.reconstruct
         )
 
         return consumers

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -116,6 +116,9 @@ class TangoMixin:
 
     """TangoMixin does not need a producer becuase the backend processes image streams which do not
     come via concert.
+
+    :param device: a Tango device proxy
+    :param endpoints: a dictionary mapping acquisitions to their endpoints. The key is the name of the acquisition.
     """
     async def __ainit__(self, device, endpoints: dict) -> Awaitable:
         self._device = device
@@ -137,7 +140,7 @@ class Benchmarker(TangoMixin, base.Benchmarker):
 
         for acq in acquisitions:
             consumers[acq] = TangoConsumer(
-                self._device, self._endpoints[acq], self.start_timer, corofunc_args=(acq.name,)
+                self._device, self._endpoints[acq.name], self.start_timer, corofunc_args=(acq.name,)
             )
 
         return consumers
@@ -183,7 +186,7 @@ class ImageWriter(TangoMixin, base.ImageWriter):
 
         for acq in acquisitions:
             consumers[acq] = TangoConsumer(
-                self._device, self._endpoints[acq], prepare_wrapper(acq.name)
+                self._device, self._endpoints[acq.name], prepare_wrapper(acq.name)
             )
 
         return consumers
@@ -205,7 +208,7 @@ class LiveView(base.LiveView):
             pass
 
         for acq in acquisitions:
-            consumers[acq] = LiveViewConsumer(self._viewer, self.endpoints[acq], consume)
+            consumers[acq] = LiveViewConsumer(self._viewer, self.endpoints[acq.name], consume)
 
         return consumers
 
@@ -265,14 +268,14 @@ class OnlineReconstruction(TangoMixin, base.OnlineReconstruction):
 
         if self._do_normalization:
             consumers[darks] = TangoConsumer(
-                self._device, self._endpoints[darks], self.update_darks
+                self._device, self._endpoints[darks.name], self.update_darks
             )
             consumers[flats] = TangoConsumer(
-                self._device, self._endpoints[flats], self.update_flats
+                self._device, self._endpoints[flats.name], self.update_flats
             )
 
         consumers[radios] = TangoConsumer(
-            self._device, self._endpoints[radios], self.reconstruct
+            self._device, self._endpoints[radios.name], self.reconstruct
         )
 
         return consumers

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -397,21 +397,16 @@ class Experiment(RunnableParameterizable):
 
     def add(self, acquisition):
         """
-        Add *acquisition* to the acquisition list and make it accessible as
-        an attribute::
+        Add *acquisition* to the acquisition list.
 
-            frames = Acquisition(...)
+            frames = Acquisition('frames', ...)
             experiment.add(frames)
-            # This is possible
-            experiment.frames
         """
         self._acquisitions.append(acquisition)
-        setattr(self, acquisition.name, acquisition)
 
     def remove(self, acquisition):
         """Remove *acquisition* from experiment."""
         self._acquisitions.remove(acquisition)
-        delattr(self, acquisition.name)
 
     def swap(self, first, second):
         """

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -24,7 +24,6 @@ from concert.base import (
 )
 from concert.helpers import get_basename
 from concert.loghandler import AsyncLoggingHandlerCloser
-from functools import partial
 
 
 LOG = logging.getLogger(__name__)
@@ -39,32 +38,29 @@ class Consumer:
     :param corofunc: a consumer coroutine function
     :param corofunc_args: a list or tuple of *corofunc* arguemnts
     :param corofunc_kwargs: a list or tuple of *corofunc* keyword arguemnts
-    :param addon: a :class:`~concert.experiments.addons.Addon` object
     """
-    def __init__(self, corofunc, corofunc_args=(), corofunc_kwargs=None, addon=None):
+    def __init__(self, corofunc, corofunc_args=(), corofunc_kwargs=None):
         self._corofunc = corofunc
-        self.addon = addon
         self.args = corofunc_args
         self.kwargs = {} if corofunc_kwargs is None else corofunc_kwargs
+
+    @property
+    def remote(self):
+        return False
 
     @property
     def corofunc(self):
         return self._corofunc
 
     async def __call__(self, producer):
-        corofunc = self._corofunc
-        if producer:
-            corofunc = partial(self._corofunc, producer)
-
         st = time.perf_counter()
-        await corofunc(*self.args, **self.kwargs)
+        await self.corofunc(producer, *self.args, **self.kwargs)
         LOG.debug('%s finished in %.3f s', self._corofunc.__qualname__, time.perf_counter() - st)
 
 
 class Acquisition(RunnableParameterizable):
     """
-    An acquisition acquires data, gets it and sends it to consumers. This is a base class for local
-    and remote acquisitions and must not be used directly.
+    An acquisition acquires data, gets it and sends it to consumers.
 
     .. py:attribute:: name
 
@@ -118,7 +114,7 @@ class Acquisition(RunnableParameterizable):
 
     def add_consumer(self, consumer):
         """Add *consumer*, *remote* must match this acquisition mode."""
-        if self.remote ^ consumer.corofunc.remote:
+        if self.remote ^ consumer.remote:
             raise ConsumerError("Cannot attach local consumers to remote producers and vice versa")
         self._consumers.append(consumer)
         LOG.debug('Adding %s to acquisition %s', consumer.__class__.__name__, self.name)
@@ -167,13 +163,12 @@ class Acquisition(RunnableParameterizable):
 
         # Connect the producer to all consumers
         for consumer in self._consumers:
-            if consumer.addon is not None:
-                await self.producer.register_endpoint(consumer.addon.endpoint)
-                await consumer.addon.connect_endpoint()
+            await self.producer.register_endpoint(consumer.endpoint)
+            await consumer.connect_endpoint()
 
         tasks = [start(producer_coro())]
         self._producer_task = tasks[0]
-        tasks += [start(consumer(None)) for consumer in self._consumers]
+        tasks += [start(consumer()) for consumer in self._consumers]
         LOG.debug(
             "`%s': starting producer `%s' and consumers %s",
             self.name,
@@ -215,9 +210,8 @@ class Acquisition(RunnableParameterizable):
         finally:
             # No matter what happens disconnect the producers and consumers to have a clean state
             for consumer in self._consumers:
-                if consumer.addon is not None:
-                    await self.producer.unregister_endpoint(consumer.addon.endpoint)
-                    await consumer.addon.disconnect_endpoint()
+                await self.producer.unregister_endpoint(consumer.endpoint)
+                await consumer.disconnect_endpoint()
 
     @background
     @check(source=['standby', 'error', 'cancelled'], target=['standby', 'cancelled'])

--- a/concert/tests/integration/test_experiments.py
+++ b/concert/tests/integration/test_experiments.py
@@ -215,12 +215,11 @@ class TestExperiment(TestExperimentBase):
             self.experiment.acquisitions.remove(self.bar)
 
     def test_add(self):
-        self.assertEqual(self.experiment.foo, self.foo)
-        self.assertEqual(self.experiment.bar, self.bar)
+        self.assertEqual(self.experiment.get_acquisition("foo"), self.foo)
+        self.assertEqual(self.experiment.get_acquisition("bar"), self.bar)
 
     def test_remove(self):
         self.experiment.remove(self.bar)
-        self.assertFalse(hasattr(self.experiment, 'bar'))
         self.assertNotIn(self.bar, self.experiment.acquisitions)
 
     async def test_prepare(self):


### PR DESCRIPTION
Addresses #565.

## A full-blown working example

```python
import logging
import numpy as np
import os
import zmq
import concert
concert.require("0.30.1")

from concert.devices.cameras.dummy import Camera
from concert.helpers import CommData
from concert.quantities import q
from concert.networking.base import get_tango_device
from concert.session.utils import ddoc, dstate, pdoc, code_of
from concert.experiments.base import Acquisition, Experiment, remote
from concert.experiments.addons import tango as tango_addons
from concert.storage import RemoteDirectoryWalker
from concert.ext.viewers import PyQtGraphViewer


concert.config.PROGRESS_BAR = False
LOG = logging.getLogger(__name__)
WIDTH = HEIGHT = 256
NUM_RADIOS = 30


viewer = await PyQtGraphViewer(show_refresh_rate=True)
slice_viewer = await PyQtGraphViewer(show_refresh_rate=True, title="Slices")
camera_1 = await Camera(background=np.zeros((HEIGHT, WIDTH)))
camera_2 = await Camera(background=np.ones((HEIGHT, WIDTH)) * 1000)  # Distinguish this camera from the other, mean will be higher
await camera_1.set_frame_rate(10 / q.s)
await camera_2.set_frame_rate(10 / q.s)

walker_device = get_tango_device(f'{os.uname()[1]}:1238/concert/tango/walker#dbase=no', timeout=1000 * q.s)
walker = await RemoteDirectoryWalker(
    device=walker_device,
    root='/mnt/fast3/remote-tests',
    bytes_per_file=2 ** 40,
)


class TwoCameraExperiment(Experiment):
   async def __ainit__(self, camera_1, camera_2):
      # camera_1 and camera_2 are two different remote cameras running on different machines
      dark_acq = await Acquisition("darks", self._take_darks, producer=camera_1)
      flat_acq = await Acquisition("flats", self._take_flats, producer=camera_1)
      radio_acq = await Acquisition("radios", self._take_radios, producer=camera_2)
      await super().__ainit__([dark_acq, flat_acq, radio_acq], walker=walker)

   @remote
   async def _take_darks(self):
      await self.get_acquisition('darks').producer.start_recording()
      await self.get_acquisition('darks').producer.grab_send(10)
      await self.get_acquisition('darks').producer.stop_recording()

   @remote
   async def _take_flats(self):
      await self.get_acquisition('flats').producer.start_recording()
      await self.get_acquisition('flats').producer.grab_send(20)
      await self.get_acquisition('flats').producer.stop_recording()

   @remote
   async def _take_radios(self):
      await self.get_acquisition('radios').producer.start_recording()
      await self.get_acquisition('radios').producer.grab_send(NUM_RADIOS)
      await self.get_acquisition('radios').producer.stop_recording()

ex = await TwoCameraExperiment(camera_1, camera_2)

SERVERS = {
        "writer": {
            'darks': CommData("localhost", port=8992, socket_type=zmq.PUSH),
            'flats': CommData("localhost", port=8992, socket_type=zmq.PUSH),
            'radios': CommData("localhost", port=9992, socket_type=zmq.PUSH), # use different port for camera_2
        },
        "reco": {
            'darks': CommData("localhost", port=8993, socket_type=zmq.PUSH),
            'flats': CommData("localhost", port=8993, socket_type=zmq.PUSH),
            'radios': CommData("localhost", port=9993, socket_type=zmq.PUSH), # use different port for camera_2
        },
        "live": {
            'darks': CommData("localhost", port=8995, socket_type=zmq.PUB, sndhwm=1),
            'flats': CommData("localhost", port=8995, socket_type=zmq.PUB, sndhwm=1),
            'radios': CommData("localhost", port=9995, socket_type=zmq.PUB, sndhwm=1), # use different port for camera_2
        },
        "bench": {
            'darks': CommData("localhost", port=8997, socket_type=zmq.PUSH),
            'flats': CommData("localhost", port=8997, socket_type=zmq.PUSH),
            'radios': CommData("localhost", port=9997, socket_type=zmq.PUSH), # use different port for camera_2
        }
}

# Live View
if "live" in SERVERS:
    live = await tango_addons.LiveView(viewer, SERVERS["live"], ex)

# Writer
writer = await tango_addons.ImageWriter(ex, SERVERS["writer"])

if "bench" in SERVERS:
    bench_device = get_tango_device(f'{os.uname()[1]}:1240/concert/tango/benchmarker#dbase=no', timeout=1000 * q.s)
    bench = await tango_addons.Benchmarker(ex, bench_device, SERVERS["bench"])

# Online Reco
if "reco" in SERVERS:
    reco_device = get_tango_device(f'{os.uname()[1]}:1237/concert/tango/reco#dbase=no', timeout=1000 * q.s)
    reco = await tango_addons.OnlineReconstruction(reco_device, ex,
                                                   SERVERS["reco"],
                                                   do_normalization=True,
                                                   average_normalization=True,
                                                   slice_directory="online-slices",
                                                   viewer=slice_viewer)
    await reco.set_region([0., 1., 1.])
    await reco.set_center_position_x([WIDTH / 2] * q.px)
    await reco.set_fix_nan_and_inf(True)
    await reco_device.write_attribute('center_position_z', [(await camera_1.get_roi_height()).magnitude / 2 + 0.5])
    await reco_device.write_attribute('number', NUM_RADIOS)
    await reco_device.write_attribute('overall_angle', np.pi)
    await reco_device.setup_walker(
        [
            f'{os.uname()[1]}:2238/concert/tango/walker#dbase=no',
            '/home/tomas/data/remote-tests',
            "tcp", "localhost", "8996"
        ]
    )
```

## Tango setup

```bash
concert tango walker --port 1238  # Writer
concert tango walker --port 2238  # Online reco writer
concert tango reco --port 1237
concert tango benchmarker --port 1240
```

After the experiment run, darks and flats have mean 100 and radios 1000, which shows that radios use the second camera.