### PR TITLE
Sample detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
 
     steps:
@@ -43,11 +43,11 @@ jobs:
       run: |
         coverage run --source=concert -m pytest --ignore=concert/tests/integration/scenarios -m "not skip_ci" 
     - name: Convert coverage to xml
-      if: matrix.python-version == '3.12'
+      if: matrix.python-version == '3.14'
       run: |
         coverage xml --omit="concert/tests/util/_package/_module.py"
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.12'
+      if: matrix.python-version == '3.14'
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     libgirepository-1.0-dev \
     ninja-build \
     libzmq5-dev \
+	libjson-c-dev \
     libjson-glib-dev \
     iputils-ping \
     iproute2 \

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Concert
 =======
 
-.. image:: https://img.shields.io/badge/Python-3.8+-blue
+.. image:: https://img.shields.io/badge/Python-3.10+-blue
     :target: https://www.python.org/downloads
 
 .. image:: https://badge.fury.io/py/concert.svg
@@ -19,7 +19,7 @@ Concert
 
 
 *Concert* is a light-weight control system interface to control Tango and native
-devices. It requires Python >= 3.8. It can be used as a library::
+devices. It requires Python >= 3.10. It can be used as a library::
 
     from concert.quantities import q
     from concert.devices.motors.dummy import LinearMotor

--- a/concert/base.py
+++ b/concert/base.py
@@ -12,7 +12,6 @@ from concert.helpers import memoize, get_state_from_awaitable
 from concert.coroutines.base import background, get_event_loop, run_in_loop, wait_until
 from concert.quantities import q
 
-
 LOG = logging.getLogger(__name__)
 _RUN_IN_LOOP_ERR_TMPL = "Someone is trying to use `{}' " \
                         "inside `async def' code which is not allowed, please " \
@@ -33,6 +32,10 @@ def _getter_not_implemented(*args):
 
 def _getter_target_not_implemented(*args):
     raise AccessorNotImplementedError
+
+
+async def _none():
+    return None
 
 
 async def _execute_func(func, instance, *args, **kwargs):
@@ -66,6 +69,7 @@ def _find_object_by_name(instance):
     """Find variable name by *instance*. This is supposed to be used only in the
     :meth:`.Parameter.__set__`.
     """
+
     def _is_name_ok(instance_name):
         return instance_name and instance_name not in ['instance', 'self']
 
@@ -131,7 +135,6 @@ class TransitionNotAllowed(FSMError):
 
 
 class StateError(Exception):
-
     """Raised in state check functions of devices."""
 
     def __init__(self, error_state, msg=None):
@@ -143,25 +146,21 @@ class StateError(Exception):
 
 
 class UnitError(ValueError):
-
     """Raised when an operation is passed value with an incompatible unit."""
     pass
 
 
 class LimitError(ValueError):
-
     """Raised when an operation is passed a value that exceeds a limit."""
     pass
 
 
 class SoftLimitError(LimitError):
-
     """Raised when a soft limit is hit on the device."""
     pass
 
 
 class HardLimitError(StateError):
-
     """Raised when device goes into hardlimit error state."""
 
     def __init__(self, error_state='hard-limit', msg=None):
@@ -169,7 +168,6 @@ class HardLimitError(StateError):
 
 
 class ParameterError(Exception):
-
     """Raised when a parameter is accessed that does not exists."""
 
     def __init__(self, parameter):
@@ -178,12 +176,10 @@ class ParameterError(Exception):
 
 
 class AccessorNotImplementedError(NotImplementedError):
-
     """Raised when a setter or getter is not implemented."""
 
 
 class ReadAccessError(Exception):
-
     """Raised when user tries to read a parameter that cannot be read."""
 
     def __init__(self, parameter):
@@ -193,7 +189,6 @@ class ReadAccessError(Exception):
 
 
 class TargetAccessError(Exception):
-
     """Raised when user tries to read parameter's target value that cannot be read."""
 
     def __init__(self, parameter):
@@ -203,7 +198,6 @@ class TargetAccessError(Exception):
 
 
 class WriteAccessError(Exception):
-
     """Raised when user tries to read a parameter that cannot be read."""
 
     def __init__(self, parameter):
@@ -213,7 +207,6 @@ class WriteAccessError(Exception):
 
 
 class SelectionError(Exception):
-
     """Raised when user tries to set selection parameter to unknown value."""
 
     def __init__(self, parameter, value, values):
@@ -223,7 +216,6 @@ class SelectionError(Exception):
 
 
 class LockError(Exception):
-
     """Raised when parameter is locked."""
 
     pass
@@ -235,6 +227,7 @@ def transition(immediate=None, target=None, state_name='state'):
     and cleanup logic must take place in the callable to be wrapped.
     *state_name* can be used to define the state if multiple states are used.
     """
+
     def wrapped(func):
         @functools.wraps(func)
         async def call_func(instance, *args, **kwargs):
@@ -278,6 +271,7 @@ def check(source: Union[str, List[str]] = '*', target: Union[str, List[str]] = '
     target states.
     *state_name* can be used to define the state if multiple states are used.
     """
+
     async def check_now(instance, allowed_states, state_str):
         state = await instance[state_name].get()
         if state not in allowed_states and '*' not in allowed_states:
@@ -318,7 +312,6 @@ def check(source: Union[str, List[str]] = '*', target: Union[str, List[str]] = '
 
 
 class Parameter(object):
-
     """A parameter with getter and setter.
 
     Parameters are similar to normal Python properties and can additionally
@@ -371,23 +364,14 @@ class Parameter(object):
 
     @memoize
     def setter_name(self):
-        if self.fset:
-            return self.fset.__name__
-
         return '_set_' + self.name
 
     @memoize
     def getter_name(self):
-        if self.fget:
-            return self.fget.__name__
-
         return '_get_' + self.name
 
     @memoize
     def getter_name_target(self):
-        if self.fget_target:
-            return self.fget_target.__name__
-
         return '_get_target_' + self.name
 
     @memoize
@@ -448,7 +432,6 @@ class Parameter(object):
 
 
 class State(Parameter):
-
     """
     Finite state machine.
 
@@ -505,7 +488,6 @@ class State(Parameter):
 
 
 class Selection(Parameter):
-
     """A :class:`.Parameter` that can take a value out of pre-defined list."""
 
     def __init__(self, iterable, fget=None, fset=None, check=None, help=None):
@@ -520,7 +502,6 @@ class Selection(Parameter):
 
 
 class Quantity(Parameter):
-
     """A :class:`.Parameter` associated with a unit."""
 
     def __init__(self, unit, fget=None, fset=None, fget_target=None, lower=None, upper=None,
@@ -550,6 +531,96 @@ class Quantity(Parameter):
     def convert(self, value):
         return value.to(self.unit)
 
+    @memoize
+    def lower_user_setter_name(self):
+        return '_set_' + self.name + '_lower_user_limit'
+
+    @memoize
+    def lower_user_getter_name(self):
+        return '_get_' + self.name + "_lower_user_limit"
+
+    @memoize
+    def upper_user_setter_name(self):
+        return '_set_' + self.name + '_upper_user_limit'
+
+    @memoize
+    def upper_user_getter_name(self):
+        return '_get_' + self.name + "_upper_user_limit"
+
+    @memoize
+    def lower_external_getter_name(self):
+        return '_get_' + self.name + "_lower_external_limit"
+
+    @memoize
+    def upper_external_getter_name(self):
+        return '_get_' + self.name + "_upper_external_limit"
+
+    @memoize
+    def get_lower_user_getter(self, instance):
+        if self.user_lower_getter:
+            lower_user = functools.partial(self.user_lower_getter, instance)
+        elif hasattr(instance, self.lower_user_getter_name()):
+            lower_user = getattr(instance, self.lower_user_getter_name())
+        else:
+            lower_user = _getter_not_implemented
+
+        return lower_user
+
+    @memoize
+    def get_upper_user_getter(self, instance):
+        if self.user_upper_getter:
+            upper_user = functools.partial(self.user_upper_getter, instance)
+        elif hasattr(instance, self.upper_user_getter_name()):
+            upper_user = getattr(instance, self.upper_user_getter_name())
+        else:
+            upper_user = _getter_not_implemented
+
+        return upper_user
+
+    @memoize
+    def get_lower_external_getter(self, instance):
+        if self.external_lower_getter:
+            lower_external = self.external_lower_getter
+        elif hasattr(instance, self.lower_external_getter_name()):
+            lower_external = getattr(instance, self.lower_external_getter_name())
+        else:
+            lower_external = _none
+
+        return lower_external
+
+    @memoize
+    def get_upper_external_getter(self, instance):
+        if self.external_upper_getter:
+            upper_external = self.external_upper_getter
+        elif hasattr(instance, self.upper_external_getter_name()):
+            upper_external = getattr(instance, self.upper_external_getter_name())
+        else:
+            upper_external = _none
+
+        return upper_external
+
+    @memoize
+    def get_lower_user_setter(self, instance):
+        if self.user_lower_setter:
+            lower_user = functools.partial(self.user_lower_setter, instance)
+        elif hasattr(instance, self.lower_user_setter_name()):
+            lower_user = getattr(instance, self.lower_user_setter_name())
+        else:
+            lower_user = _setter_not_implemented
+
+        return lower_user
+
+    @memoize
+    def get_upper_user_setter(self, instance):
+        if self.user_upper_setter:
+            upper_user = functools.partial(self.user_upper_setter, instance)
+        elif hasattr(instance, self.upper_user_setter_name()):
+            upper_user = getattr(instance, self.upper_user_setter_name())
+        else:
+            upper_user = _setter_not_implemented
+
+        return upper_user
+
 
 def quantity(unit=None, lower=None, upper=None, data=None, check=None, help=None):
     """
@@ -577,7 +648,6 @@ def quantity(unit=None, lower=None, upper=None, data=None, check=None, help=None
 
 
 class ParameterValue(object):
-
     """Value object of a :class:`.Parameter`."""
 
     def __init__(self, instance, parameter):
@@ -752,6 +822,7 @@ class ParameterValue(object):
         """Lock parameter for writing. If *permament* is True the parameter
         cannot be unlocked anymore.
         """
+
         def unlock_not_allowed():
             raise LockError("Parameter `{}' cannot be unlocked".format(self._parameter.name))
 
@@ -768,6 +839,7 @@ class ParameterValue(object):
         """Wait until the parameter value is *value*. *sleep_time* is the time to sleep
         between consecutive checks. *timeout* specifies the maximum waiting time.
         """
+
         async def condition():
             return await self.get() == value
 
@@ -775,7 +847,6 @@ class ParameterValue(object):
 
 
 class StateValue(ParameterValue):
-
     """Special :class:`.ParameterValue` implementing state parameter."""
 
     @background
@@ -813,6 +884,7 @@ class QuantityValue(ParameterValue):
 
     def lock_limits(self, permanent=False):
         """Lock limits, if *permanent* is True the limits cannot be unlocked anymore."""
+
         def unlock_not_allowed():
             raise LockError('Limits are locked permanently')
 
@@ -867,7 +939,12 @@ class QuantityValue(ParameterValue):
             raise ValueError('Lower limit must be lower than upper')
         if self._user_lower_setter:
             await self._user_lower_setter(value)
-        else:
+            return
+
+        try:
+            setter = self._parameter.get_lower_user_setter(self._instance)
+            await setter(value, *self._parameter.data_args)
+        except AccessorNotImplementedError:
             self._lower = value
 
     @property
@@ -913,7 +990,12 @@ class QuantityValue(ParameterValue):
             raise ValueError('Upper limit must be greater than lower')
         if self._user_upper_setter:
             await self._user_upper_setter(value)
-        else:
+            return
+
+        try:
+            setter = self._parameter.get_upper_user_setter(self._instance)
+            await setter(value, *self._parameter.data_args)
+        except AccessorNotImplementedError:
             self._upper = value
 
     @property
@@ -928,10 +1010,14 @@ class QuantityValue(ParameterValue):
 
     @background
     async def get_upper_user(self):
-        if self._user_upper_getter is None:
+        if self._user_upper_getter:
+            return await self._user_upper_getter(*self._parameter.data_args)
+
+        try:
+            getter = self._parameter.get_upper_user_getter(self._instance)
+            return await getter(*self._parameter.data_args)
+        except AccessorNotImplementedError:
             return self._upper
-        else:
-            return await self._user_upper_getter()
 
     @property
     def lower_user(self):
@@ -945,10 +1031,14 @@ class QuantityValue(ParameterValue):
 
     @background
     async def get_lower_user(self):
-        if self._user_lower_getter is None:
+        if self._user_lower_getter:
+            return await self._user_lower_getter(*self._parameter.data_args)
+
+        try:
+            getter = self._parameter.get_lower_user_getter(self._instance)
+            return await getter(*self._parameter.data_args)
+        except AccessorNotImplementedError:
             return self._lower
-        else:
-            return await self._user_lower_getter()
 
     @property
     def lower_external(self):
@@ -960,12 +1050,12 @@ class QuantityValue(ParameterValue):
             )
         )
 
-    @background
     async def get_lower_external(self):
-        if self._external_lower_getter is None:
+        try:
+            getter = self._parameter.get_lower_external_getter(self._instance)
+            return await getter(*self._parameter.data_args)
+        except AccessorNotImplementedError:
             return None
-        else:
-            return await self._external_lower_getter()
 
     @property
     def upper_external(self):
@@ -977,12 +1067,12 @@ class QuantityValue(ParameterValue):
             )
         )
 
-    @background
     async def get_upper_external(self):
-        if self._external_upper_getter is None:
+        try:
+            getter = self._parameter.get_upper_external_getter(self._instance)
+            return await getter(*self._parameter.data_args)
+        except AccessorNotImplementedError:
             return None
-        else:
-            return await self._external_upper_getter()
 
     @property
     async def info_table(self):
@@ -1057,6 +1147,7 @@ class QuantityValue(ParameterValue):
         actual value and *value*. *sleep_time* is the time to sleep between consecutive checks.
         *timeout* specifies the maximum waiting time.
         """
+
         async def condition():
             """Take care of rountind errors"""
             diff = await self.get() - value
@@ -1080,7 +1171,6 @@ class QuantityValue(ParameterValue):
 
 
 class SelectionValue(ParameterValue):
-
     """Descriptor for :class:`.Selection` class."""
 
     def __init__(self, instance, selection):
@@ -1105,7 +1195,6 @@ class SelectionValue(ParameterValue):
 
 
 class AsyncType(abc.ABCMeta):
-
     """
     Metaclass which allows an awaitable constructor `__ainit__(...)' instead of `__init__(...)' and
     thus enables async object initialization `obj = await Class(...)'. `__ainit__(...)` must return
@@ -1185,7 +1274,6 @@ class AsyncObject(metaclass=AsyncType):
 
 
 class Parameterizable(AsyncObject, abc.ABC):
-
     """
     Collection of parameters.
 
@@ -1219,6 +1307,126 @@ class Parameterizable(AsyncObject, abc.ABC):
 
         param.position = 0 * q.mm
         print param.position
+
+
+    Setting limits and values can be handles in two ways::
+
+        lower_foo = None
+        upper_foo = None
+        position_foo = 0 * q.mm
+
+
+        def get_lower_foo_softlimit():
+            global lower_foo
+            return lower_foo
+
+
+        def get_upper_foo_softlimit():
+            global upper_foo
+            return upper_foo
+
+
+        def set_lower_foo_softlimit(value):
+            global lower_foo
+            lower_foo = value
+
+
+        def set_upper_foo_softlimit(value):
+            global upper_foo
+            upper_foo = value
+
+
+        def get_foo_from_hardware():
+            global position_foo
+            return position_foo
+
+
+        def send_foo_to_hardware(value):
+            global position_foo
+            position_foo = value
+
+
+        from concert.base import Quantity, Parameterizable
+
+
+        class DeviceWithClassGetter(Parameterizable):
+            foo = Quantity(q.mm)
+
+            async def __ainit__(self):
+                await super().__ainit__()
+
+            async def _get_foo(self):
+                return get_foo_from_hardware()
+
+            async def _set_foo(self, value):
+                send_foo_on_hardware(value)
+
+            async def _get_foo_lower_external_limit(self):
+                return -4 * q.mm
+
+            async def _get_foo_upper_external_limit(self):
+                return 4 * q.mm
+
+            async def _get_foo_lower_user_limit(self):
+                return get_lower_foo_softlimit()
+
+            async def _get_foo_upper_user_limit(self):
+                return get_upper_foo_softlimit()
+
+            async def _set_foo_lower_user_limit(self, val):
+                return set_lower_foo_softlimit(val)
+
+            async def _set_foo_upper_user_limit(self, val):
+                return set_upper_foo_softlimit(val)
+
+
+        lower_bar = None
+        upper_bar = None
+        position_bar = 0 * q.mm
+
+
+        async def get_lower_bar_softlimit():
+            global lower_bar
+            return lower_bar
+
+
+        async def get_upper_bar_softlimit():
+            global upper_bar
+            return upper_bar
+
+
+        async def set_lower_bar_softlimit(value):
+            global lower_bar
+            lower_bar = value
+
+
+        async def set_upper_bar_softlimit(value):
+            global upper_bar
+            upper_bar = value
+
+
+        async def get_bar_from_hardware(cls):
+            global position_bar
+            return position_bar
+
+
+        async def send_bar_to_hardware(cls, value):
+            global position_bar
+            position_bar = value
+
+
+        class DeviceWithSetterInConstructor(Parameterizable):
+            bar = Quantity(q.mm,
+                        fget=get_bar_from_hardware,
+                        fset=send_bar_to_hardware,
+                        user_lower_getter=get_lower_bar_softlimit,
+                        user_upper_getter=get_upper_bar_softlimit,
+                        user_lower_setter=set_lower_bar_softlimit,
+                        user_upper_setter=set_upper_bar_softlimit)
+
+            async def __ainit__(self):
+                await super().__ainit__()
+
     """
 
     async def __ainit__(self):
@@ -1260,15 +1468,49 @@ class Parameterizable(AsyncObject, abc.ABC):
     async def info_table(self):
         from concert.session.utils import get_default_table
 
-        table = get_default_table(["Parameter", "Value"])
+        table = get_default_table(
+            ["Parameter", "Value", "Target", "lower", "upper", "lower user", "upper user",
+             "lower external", "upper external"])
         table.border = False
+        table.vertical_char = "|"
+        table.vrules = True
 
         for param in self:
             try:
                 value = str(await param.get())
             except ReadAccessError:
                 value = 'N/A'
-            table.add_row([param.name, value])
+            try:
+                target = str(await param.get_target())
+            except TargetAccessError:
+                target = 'N/A'
+            try:
+                lower_limit = str(await param.get_lower())
+            except AttributeError:
+                lower_limit = ''
+            try:
+                upper_limit = str(await param.get_upper())
+            except AttributeError:
+                upper_limit = ''
+            try:
+                lower_external_limit = str(await param.get_lower_external())
+            except AttributeError:
+                lower_external_limit = ''
+            try:
+                upper_external_limit = str(await param.get_upper_external())
+            except AttributeError:
+                upper_external_limit = ''
+            try:
+                lower_user_limit = str(await param.get_lower_user())
+            except AttributeError:
+                lower_user_limit = ''
+            try:
+                upper_user_limit = str(await param.get_upper_user())
+            except AttributeError:
+                upper_user_limit = ''
+
+            table.add_row([param.name, value, target, lower_limit, upper_limit, lower_user_limit,
+                           upper_user_limit, lower_external_limit, upper_external_limit])
 
         return table
 
@@ -1304,14 +1546,17 @@ class Parameterizable(AsyncObject, abc.ABC):
         if getter_name not in self.__class__.__dict__:
             def get_parameter(instance, wait_on=None):
                 return instance[param.name].get(wait_on=wait_on)
+
             setattr(self.__class__, getter_name, get_parameter)
         if setter_name not in self.__class__.__dict__:
             def set_parameter(instance, parameter_value, wait_on=None):
                 return instance[param.name].set(parameter_value, wait_on=wait_on)
+
             setattr(self.__class__, setter_name, set_parameter)
         if target_getter_name not in self.__class__.__dict__:
             def get_target_parameter(instance, wait_on=None):
                 return instance[param.name].get_target(wait_on=wait_on)
+
             setattr(self.__class__, target_getter_name, get_target_parameter)
 
         if not hasattr(self, '_set_' + param.name):

--- a/concert/devices/cameras/base.py
+++ b/concert/devices/cameras/base.py
@@ -253,7 +253,7 @@ class Camera(Device):
         :type endpoint: concert.helpers.CommData
         """
         if endpoint in self._senders:
-            self._senders[endpoint].close()
+            await self._senders[endpoint].close()
             del self._senders[endpoint]
 
     async def register_endpoint(self, endpoint: CommData) -> None:
@@ -266,7 +266,7 @@ class Camera(Device):
         if endpoint in self._senders:
             raise ValueError("zmq endpoint already in list")
 
-        self._senders[endpoint] = ZmqSender(
+        self._senders[endpoint] = await ZmqSender(
             endpoint.server_endpoint,
             reliable=endpoint.socket_type == zmq.PUSH,
             sndhwm=endpoint.sndhwm
@@ -274,7 +274,7 @@ class Camera(Device):
 
     async def unregister_all(self) -> None:
         for sender in self._senders.values():
-            sender.close()
+            await sender.close()
         self._senders = {}
 
     @abstractmethod

--- a/concert/devices/dummy.py
+++ b/concert/devices/dummy.py
@@ -7,7 +7,6 @@ from concert.config import AIODEBUG
 from concert.devices.base import Device
 from concert.quantities import q
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -20,7 +19,6 @@ async def get_evalue(instance):
 
 
 class DummyDevice(Device):
-
     """A dummy device."""
 
     position = Quantity(unit=q.mm)
@@ -120,7 +118,6 @@ class DummyDevice(Device):
 
 
 class SelectionDevice(Device):
-
     """A dummy device with a selection."""
 
     selection = Selection(list(range(3)))
@@ -134,3 +131,131 @@ class SelectionDevice(Device):
 
     async def _set_selection(self, selection):
         self._selection = selection
+
+
+lower_foo = None
+upper_foo = None
+position_foo = 0 * q.mm
+
+
+def get_lower_foo_softlimit():
+    global lower_foo
+    return lower_foo
+
+
+def get_upper_foo_softlimit():
+    global upper_foo
+    return upper_foo
+
+
+def set_lower_foo_softlimit(value):
+    global lower_foo
+    lower_foo = value
+
+
+def set_upper_foo_softlimit(value):
+    global upper_foo
+    upper_foo = value
+
+
+def get_foo_from_hardware():
+    global position_foo
+    return position_foo
+
+
+def send_foo_to_hardware(value):
+    global position_foo
+    position_foo = value
+
+
+from concert.base import Quantity
+
+
+class DeviceWithClassGetter(Device):
+    """
+    Example of a device that uses setters/getters for limits in the device class.
+
+    A real device would talk to the hardware or a database for storing/receiving the values.
+    """
+    foo = Quantity(q.mm)
+
+    async def __ainit__(self):
+        await super().__ainit__()
+
+    async def _get_foo(self):
+        return get_foo_from_hardware()
+
+    async def _set_foo(self, value):
+        send_foo_to_hardware(value)
+
+    async def _get_foo_lower_external_limit(self):
+        return -4 * q.mm
+
+    async def _get_foo_upper_external_limit(self):
+        return 4 * q.mm
+
+    async def _get_foo_lower_user_limit(self):
+        return get_lower_foo_softlimit()
+
+    async def _get_foo_upper_user_limit(self):
+        return get_upper_foo_softlimit()
+
+    async def _set_foo_lower_user_limit(self, val):
+        return set_lower_foo_softlimit(val)
+
+    async def _set_foo_upper_user_limit(self, val):
+        return set_upper_foo_softlimit(val)
+
+
+lower_bar = None
+upper_bar = None
+position_bar = 0 * q.mm
+
+
+async def get_lower_bar_softlimit():
+    global lower_bar
+    return lower_bar
+
+
+async def get_upper_bar_softlimit():
+    global upper_bar
+    return upper_bar
+
+
+async def set_lower_bar_softlimit(value):
+    global lower_bar
+    lower_bar = value
+
+
+async def set_upper_bar_softlimit(value):
+    global upper_bar
+    upper_bar = value
+
+
+async def get_bar_from_hardware(cls):
+    global position_bar
+    return position_bar
+
+
+async def send_bar_to_hardware(cls, value):
+    global position_bar
+    position_bar = value
+
+
+class DeviceWithSetterInConstructor(Device):
+    """
+    Example of a device that uses setters/getters for limits passed to the Quantity constructor.
+
+    A real device would talk to the hardware or a database for storing/receiving the values.
+    """
+
+    bar = Quantity(q.mm,
+                   fget=get_bar_from_hardware,
+                   fset=send_bar_to_hardware,
+                   user_lower_getter=get_lower_bar_softlimit,
+                   user_upper_getter=get_upper_bar_softlimit,
+                   user_lower_setter=set_lower_bar_softlimit,
+                   user_upper_setter=set_upper_bar_softlimit)
+
+    async def __ainit__(self):
+        await super().__ainit__()

--- a/concert/experiments/addons/base.py
+++ b/concert/experiments/addons/base.py
@@ -133,6 +133,10 @@ class SampleDetector(Addon):
 
         return consumers
 
+    async def detect(self, image):
+        """Detect sample in *image*."""
+        raise NotImplementedError
+
     async def stream_detect(self):
         raise NotImplementedError
 

--- a/concert/experiments/addons/base.py
+++ b/concert/experiments/addons/base.py
@@ -456,6 +456,14 @@ class OnlineReconstruction(Addon):
     async def get_volume_shape(self):
         ...
 
+    @abstractmethod
+    async def get_best_slice_index(self):
+        ...
+
+    @abstractmethod
+    async def reset_manager(self):
+        ...
+
     async def reconstruct(self, *args, **kwargs):
         await self._reconstruct(*args, **kwargs)
         await self._show_slice()
@@ -470,7 +478,10 @@ class OnlineReconstruction(Addon):
 
     async def _show_slice(self):
         if self.viewer and len(await self.get_volume_shape()) == 3:
-            index = len(np.arange(*await self.get_region())) // 2
+            if await self.get_z_parameter() == "center-position-x":
+                index = await self.get_best_slice_index()
+            else:
+                index = len(np.arange(*await self.get_region())) // 2
             await self.viewer.show(await self.get_slice(z=index))
             await self.viewer.set_title(await self.experiment.get_current_name())
 

--- a/concert/experiments/addons/base.py
+++ b/concert/experiments/addons/base.py
@@ -114,6 +114,29 @@ class Benchmarker(Addon):
         raise NotImplementedError
 
 
+class SampleDetector(Addon):
+
+    """Sample detection addon."""
+
+    async def __ainit__(self, experiment, acquisitions=None):
+        await super().__ainit__(experiment, acquisitions=acquisitions)
+
+    def _make_consumers(self, acquisitions):
+        consumers = {}
+
+        for acq in acquisitions:
+            consumers[acq] = AcquisitionConsumer(
+                self.stream_detect,
+                addon=self if self.stream_detect.remote else None,
+                reliable=False if self.stream_detect.remote else True
+            )
+
+        return consumers
+
+    async def stream_detect(self):
+        raise NotImplementedError
+
+
 class ImageWriter(Addon):
 
     """An addon which writes images to disk.

--- a/concert/experiments/addons/local.py
+++ b/concert/experiments/addons/local.py
@@ -1,5 +1,8 @@
+import functools
+import multiprocessing
 import os
 import numpy as np
+from multiprocessing.pool import ThreadPool
 from concert.coroutines.base import async_generate, background
 from concert.coroutines.sinks import Accumulate
 from concert.experiments.addons import base
@@ -126,6 +129,20 @@ class OnlineReconstruction(base.OnlineReconstruction):
         if self._manager.volume is None:
             raise RuntimeError("Volume not available yet")
         return self._manager.volume.shape
+
+    async def get_best_slice_index(self):
+        def compute_sag_metric(volume, index):
+            return np.sum(np.abs(np.gradient(volume[index])))
+
+        pool = ThreadPool(processes=max(1, multiprocessing.cpu_count() - 2))
+        func = functools.partial(compute_sag_metric, self._manager.volume)
+        result = pool.map(func, np.arange(self._manager.volume.shape[0]))
+
+        return np.argmin(result)
+
+    async def reset_manager(self):
+        if self._manager:
+            self._manager.reset()
 
     async def _reconstruct(self, producer=None, slice_directory=None):
         if producer is None:

--- a/concert/experiments/addons/local.py
+++ b/concert/experiments/addons/local.py
@@ -130,7 +130,7 @@ class OnlineReconstruction(base.OnlineReconstruction):
             raise RuntimeError("Volume not available yet")
         return self._manager.volume.shape
 
-    async def get_best_slice_index(self):
+    async def _get_best_slice_index(self):
         def compute_sag_metric(volume, index):
             return np.sum(np.abs(np.gradient(volume[index])))
 

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -205,7 +205,7 @@ class OnlineReconstruction(TangoMixin, base.OnlineReconstruction):
     async def get_volume_shape(self):
         return await self._device.get_volume_shape()
 
-    async def get_best_slice_index(self):
+    async def _get_best_slice_index(self):
         return await self._device.get_best_slice_index()
 
     async def reset_manager(self):

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -104,20 +104,20 @@ class LiveView(base.LiveView):
         self._orig_limits = await viewer.get_limits()
 
     async def connect_endpoint(self):
-        self._viewer.subscribe(self.endpoint.client_endpoint)
+        self._viewer.subscribe(self.endpoint.client_endpoint, "image")
 
     async def disconnect_endpoint(self):
-        self._viewer.unsubscribe()
+        self._viewer.unsubscribe(self.endpoint.client_endpoint)
 
     @remote
     async def consume(self):
         try:
             if await self._viewer.get_limits() == 'stream':
-                self._viewer.unsubscribe()
+                self._viewer.unsubscribe(self.endpoint.client_endpoint)
                 # Force viewer to update the limits by unsubscribing and re-subscribing after
                 # setting limits to stream
                 await self._viewer.set_limits('stream')
-                self._viewer.subscribe(self.endpoint.client_endpoint)
+                self._viewer.subscribe(self.endpoint.client_endpoint, "image")
         finally:
             self._orig_limits = await self._viewer.get_limits()
 

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -87,6 +87,14 @@ class SampleDetector(TangoMixin, base.SampleDetector):
         await TangoMixin.__ainit__(self, device, endpoint)
         await base.SampleDetector.__ainit__(self, experiment, acquisitions=acquisitions)
 
+    async def detect(self, image):
+        encoding = f"{image.shape[1]}/{image.shape[0]}/{image.dtype}"
+        blob = image.tobytes()
+
+        result = await self._device.sample_detect((encoding, blob))
+
+        return (result[:4], result[4] / 1000)
+
     @TangoMixin.cancel_remote
     @remote
     async def stream_detect(self):

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -81,6 +81,21 @@ class Benchmarker(TangoMixin, base.Benchmarker):
         await self._device.reset()
 
 
+class SampleDetector(TangoMixin, base.SampleDetector):
+
+    async def __ainit__(self, experiment, device, endpoint, acquisitions=None):
+        await TangoMixin.__ainit__(self, device, endpoint)
+        await base.SampleDetector.__ainit__(self, experiment, acquisitions=acquisitions)
+
+    @TangoMixin.cancel_remote
+    @remote
+    async def stream_detect(self):
+        await self._device.stream_detect()
+
+    async def get_maximum_rectangle(self):
+        return await self._device.get_maximum_rectangle()
+
+
 class ImageWriter(TangoMixin, base.ImageWriter):
 
     async def __ainit__(self, experiment, endpoint, acquisitions=None):

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -197,6 +197,12 @@ class OnlineReconstruction(TangoMixin, base.OnlineReconstruction):
     async def get_volume_shape(self):
         return await self._device.get_volume_shape()
 
+    async def get_best_slice_index(self):
+        return await self._device.get_best_slice_index()
+
+    async def reset_manager(self):
+        await self._device.reset_manager()
+
     @TangoMixin.cancel_remote
     async def _reconstruct(self, cached=False, slice_directory=None):
         path = ""

--- a/concert/experiments/addons/tango.py
+++ b/concert/experiments/addons/tango.py
@@ -100,8 +100,8 @@ class SampleDetector(TangoMixin, base.SampleDetector):
     async def stream_detect(self):
         await self._device.stream_detect()
 
-    async def get_maximum_rectangle(self):
-        return await self._device.get_maximum_rectangle()
+    async def get_maximum_rectangle(self, percentile=10.0):
+        return await self._device.get_maximum_rectangle(percentile)
 
 
 class ImageWriter(TangoMixin, base.ImageWriter):

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -20,7 +20,7 @@ from concert.base import (
     Parameter,
     Selection,
     StateError,
-    RunnableParameterizable
+    RunnableParameterizable, TargetAccessError
 )
 from concert.helpers import get_basename
 from concert.loghandler import AsyncLoggingHandlerCloser
@@ -341,14 +341,42 @@ class Experiment(RunnableParameterizable):
         for name, device in self._devices_to_log.items():
             device_data = {}
             for param in device:
-                device_data[param.name] = str(await param.get())
+                device_data[param.name] = {}
+                device_data[param.name]["value"] = str(await param.get())
+                try:
+                    device_data[param.name]["target"] = str(await param.get_target())
+                except TargetAccessError:
+                    pass
+                try:
+                    device_data[param.name]["lower_limit"] = str(await param.get_lower())
+                    device_data[param.name]["upper_limit"] = str(await param.get_upper())
+                    device_data[param.name]["lower_user_limit"] = str(await param.get_lower_user())
+                    device_data[param.name]["upper_user_limit"] = str(await param.get_upper_user())
+                    device_data[param.name]["lower_external_limit"] = str(await param.get_lower_external())
+                    device_data[param.name]["upper_external_limit"] = str(await param.get_upper_external())
+                except AttributeError:
+                    pass
             metadata[name] = device_data
 
         for name, device in self._devices_to_log_optional.items():
             device_data = {}
             for param in device:
                 try:
-                    device_data[param.name] = str(await param.get())
+                    device_data[param.name] = {}
+                    device_data[param.name]["value"] = str(await param.get())
+                    try:
+                        device_data[param.name]["target"] = str(await param.get_target())
+                    except TargetAccessError:
+                        pass
+                    try:
+                        device_data[param.name]["lower_limit"] = str(await param.get_lower())
+                        device_data[param.name]["upper_limit"] = str(await param.get_upper())
+                        device_data[param.name]["lower_user_limit"] = str(await param.get_lower_user())
+                        device_data[param.name]["upper_user_limit"] = str(await param.get_upper_user())
+                        device_data[param.name]["lower_external_limit"] = str(await param.get_lower_external())
+                        device_data[param.name]["upper_external_limit"] = str(await param.get_upper_external())
+                    except AttributeError:
+                        pass
                 except Exception as e:
                     self.log.info(f"Error while logging optional device {name}")
                     self.log.info(e)

--- a/concert/ext/cmd/tango.py
+++ b/concert/ext/cmd/tango.py
@@ -1,6 +1,6 @@
 from concert.session.utils import setup_logging, SubCommand
 
-SERVER_NAMES = ['benchmarker', 'reco', 'walker']
+SERVER_NAMES = ['benchmarker', 'reco', 'walker', 'sampledetect']
 
 
 class TangoCommand(SubCommand):
@@ -58,6 +58,9 @@ class TangoCommand(SubCommand):
         if server == "walker":
             from concert.ext.tangoservers import walker
             server_class = {'class': walker.TangoRemoteWalker}
+        if server == "sampledetect":
+            from concert.ext.tangoservers import sampledetect
+            server_class = {'class': sampledetect.SampleDetect}
 
         setup_logging(server, to_stream=True, filename=logfile, loglevel=loglevel)
 

--- a/concert/ext/cmd/tango.py
+++ b/concert/ext/cmd/tango.py
@@ -34,7 +34,7 @@ class TangoCommand(SubCommand):
         Run a Tango server
 
         :param server: String defining the server type. Can be one of 'benchmarker', 'reco',
-        'walker'.
+        'sampledetect', 'walker'.
         :type server: str
         :param port: Port to run the server on. If *database* is True, this will be ignored.
         :type port: int

--- a/concert/ext/tangoservers/base.py
+++ b/concert/ext/tangoservers/base.py
@@ -20,9 +20,27 @@ class TangoRemoteProcessing(Device, metaclass=DeviceMeta):
         fset="set_endpoint"
     )
 
+    receiver_reliable = attribute(
+        label="Is ZMQ receiver reliable or not",
+        dtype=bool,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_receiver_reliable",
+        fset="set_receiver_reliable"
+    )
+
+    receiver_rcvhwm = attribute(
+        label="Receive high water mark for receiver",
+        dtype=int,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_receiver_rcvhwm",
+        fset="set_receiver_rcvhwm"
+    )
+
     def __init__(self, cl, name):
-        self._endpoint = None
-        self._receiver = ZmqReceiver()
+        self._endpoint = ""
+        self._receiver_reliable = True
+        self._receiver_rcvhm = 0
+        self._receiver = None
         self._task = None
         super().__init__(cl, name)
 
@@ -32,9 +50,20 @@ class TangoRemoteProcessing(Device, metaclass=DeviceMeta):
         await super().init_device()
         if self._task and not self._task.done():
             self.debug_stream("Cancelling task: %s", self._task.cancel())
-        if self._receiver.endpoint:
-            self._receiver.connect(self._receiver.endpoint)
+        if self._endpoint:
+            await self._create_and_connect_receiver()
         self.set_state(tango.DevState.STANDBY)
+
+    @DebugIt()
+    async def _create_and_connect_receiver(self):
+        if not self._receiver:
+            self._receiver = await ZmqReceiver(
+                endpoint=self._endpoint,
+                reliable=self._receiver_reliable,
+                rcvhwm=self._receiver_rcvhm
+            )
+
+        await self._receiver.connect(self._endpoint)
 
     @DebugIt()
     @command()
@@ -42,14 +71,15 @@ class TangoRemoteProcessing(Device, metaclass=DeviceMeta):
         """Connect to the zmq endpoint."""
         if not self._endpoint:
             raise RuntimeError("Endpoint not set")
-        self._receiver.connect(self._endpoint)
+        await self._create_and_connect_receiver()
 
     @DebugIt()
     @command()
     async def disconnect_endpoint(self):
         """Disconnect from the zmq endpoint."""
         if self._receiver:
-            self._receiver.close()
+            await self._receiver.close()
+        self._receiver = None
 
     @DebugIt()
     @command()
@@ -57,21 +87,45 @@ class TangoRemoteProcessing(Device, metaclass=DeviceMeta):
         """Stop receiving data forever."""
         if not self._endpoint:
             raise RuntimeError('Endpoint not set')
-        self._receiver.close()
-        self._receiver.connect(self._endpoint)
+        await self._receiver.close()
+        self._receiver = None
+        await self._create_and_connect_receiver()
 
     @InfoIt()
     async def get_endpoint(self):
         """Get current endpoint."""
-        return self._receiver.endpoint if self._receiver.endpoint else ''
+        return self._endpoint
 
     @InfoIt(show_args=True)
     async def set_endpoint(self, endpoint):
         """Set endpoint."""
         if self._task and not self._task.done():
             raise RuntimeError("Endpoint cannot be set while streaming")
-        self._receiver.connect(endpoint)
         self._endpoint = endpoint
+
+    @InfoIt()
+    async def get_receiver_reliable(self):
+        """Get if ZMQ receiver is reliable or not."""
+        return self._receiver_reliable
+
+    @InfoIt(show_args=True)
+    async def set_receiver_reliable(self, reliable):
+        """Set if ZMQ receiver is reliable or not."""
+        if self._task and not self._task.done():
+            raise RuntimeError("Receiver options cannot be set while streaming")
+        self._receiver_reliable = reliable
+
+    @InfoIt()
+    async def get_receiver_rcvhwm(self):
+        """Get receiver high water mark."""
+        return self._receiver_rcvhm
+
+    @InfoIt(show_args=True)
+    async def set_receiver_rcvhwm(self, rcvhwm):
+        """Set receiver high water mark."""
+        if self._task and not self._task.done():
+            raise RuntimeError("Receiver options cannot be set while streaming")
+        self._receiver_rcvhm = rcvhwm
 
     async def _process_stream(self, consumer_coro):
         """Process the data stream by *consumer_coro* and handle state."""
@@ -93,6 +147,10 @@ class TangoRemoteProcessing(Device, metaclass=DeviceMeta):
 
         if self._task and not self._task.done():
             raise RuntimeError("Previous stream still running")
+
+        if not self._receiver:
+            await self._create_and_connect_receiver()
+
         self._task = start(consumer_coro)
         self._task.add_done_callback(callback)
         self.set_state(tango.DevState.RUNNING)

--- a/concert/ext/tangoservers/bin/TangoSampleDetect
+++ b/concert/ext/tangoservers/bin/TangoSampleDetect
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+from concert.ext.tangoservers.sampledetect import SampleDetect
+from tango import GreenMode
+
+
+if __name__ == '__main__':
+    SampleDetect.run_server(green_mode=GreenMode.Asyncio)

--- a/concert/ext/tangoservers/reco.py
+++ b/concert/ext/tangoservers/reco.py
@@ -151,8 +151,8 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
             bytes_per_file=2 ** 40,
         )
         if self._sender:
-            self._sender.close()
-        self._sender = ZmqSender(endpoint=f"{protocol}://*:{port}", reliable=True)
+            await self._sender.close()
+        self._sender = await ZmqSender(endpoint=f"{protocol}://*:{port}", reliable=True)
 
     async def _reconstruct(self, cached=False, slice_directory=""):
         if cached:

--- a/concert/ext/tangoservers/reco.py
+++ b/concert/ext/tangoservers/reco.py
@@ -54,16 +54,17 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
     """
     Tango device for online 3D reconstruction from zmq image stream.
     """
-    _args = LocalGeneralBackprojectArgs()
     _default = {}
 
-    for arg, settings in _args.parameters.items():
+    # Temporary instance used only at class definition time to introspect parameters
+    # and dynamically generate Tango attributes. The actual per-instance _args is
+    # created in init_device().
+    _temp_args = LocalGeneralBackprojectArgs()
+
+    for arg, settings in _temp_args.parameters.items():
         dtype = settings.get('type')
         default = settings.get('default')
         if arg == 'gpus':
-            from gi.repository import Ufo
-            res = Ufo.Resources()
-            setattr(_args, arg, [i for i in range(len(res.get_gpu_nodes()))])
             exec(FMT.format(arg, '(int,)'))
         elif settings.get('action') == 'store_true':
             exec(FMT.format(arg, 'bool'))
@@ -88,7 +89,7 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
             _default[arg] = '' if dtype == str else dtype(0)
 
     # Do not infect the class with temp variables
-    del arg, dtype, settings
+    del arg, dtype, settings, _temp_args
 
     find_parameter_args = pipe(
         label="find_parameter_args",
@@ -99,6 +100,12 @@ class TangoOnlineReconstruction(TangoRemoteProcessing):
     async def init_device(self):
         """Inits device and communciation"""
         await super().init_device()
+
+        self._args = LocalGeneralBackprojectArgs()
+        # Set available GPU nodes on the instance-level args object
+        from gi.repository import Ufo
+        res = Ufo.Resources()
+        self._args.gpus = [i for i in range(len(res.get_gpu_nodes()))]
 
         self._manager = await GeneralBackprojectManager(
             self._args,

--- a/concert/ext/tangoservers/sampledetect.py
+++ b/concert/ext/tangoservers/sampledetect.py
@@ -1,0 +1,176 @@
+"""
+Tango server for benchmarking zmq transfers.
+"""
+import numpy as np
+import torch
+import sys
+from tango import CmdArgType, DebugIt, InfoIt
+from tango.server import attribute, AttrWriteType, command
+from .base import TangoRemoteProcessing
+from concert.networking.base import ZmqSender
+try:
+    from ultralytics import YOLO
+except ImportError:
+    print("You must install ultralytics to use sample detection", file=sys.stderr)
+
+
+class SampleDetect(TangoRemoteProcessing):
+    """
+    Device server for elmo_main.py-controller based
+    """
+
+    model_path = attribute(
+        label="AI model path for sample detection",
+        dtype=str,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_model_path",
+        fset="set_model_path"
+    )
+
+    min_confidence = attribute(
+        label="Minimum confidence for succesful detection [0 - 1]",
+        dtype=float,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_min_confidence",
+        fset="set_min_confidence"
+    )
+
+    sending_port = attribute(
+        label="Port over which detected images will be sent",
+        dtype=int,
+        access=AttrWriteType.READ_WRITE,
+        fget="get_sending_port",
+        fset="set_sending_port"
+    )
+
+    async def init_device(self):
+        await super().init_device()
+        self._model_path = ""
+        self._model = None
+        self._min_confidence = 0.25
+        self._sender = None
+        self._sending_port = 0
+
+    @InfoIt()
+    async def get_model_path(self):
+        """Get current model path."""
+        return self._model_path
+
+    @InfoIt(show_args=True)
+    async def set_model_path(self, path):
+        """Set model path."""
+        self._model_path = path
+        self._model = YOLO(path)
+
+    @InfoIt()
+    async def get_min_confidence(self):
+        """Get minimum confidence for detection."""
+        return self._min_confidence
+
+    @InfoIt(show_args=True)
+    async def set_min_confidence(self, confidence):
+        """Set minimum confidence for detection."""
+        self._min_confidence = confidence
+
+    @InfoIt()
+    async def get_sending_port(self):
+        """Get port over which images will be forwarded."""
+        return self._sending_port
+
+    @InfoIt(show_args=True)
+    async def set_sending_port(self, port):
+        """Set port over which images will be forwarded."""
+        self._sending_port = port
+        self._sender = await ZmqSender(endpoint=f"tcp://*:{port}", reliable=False, sndhwm=1)
+
+    @DebugIt()
+    @command()
+    async def stop_sending(self):
+        if self._sender:
+            await self._sender.close()
+
+    @command(dtype_out=bool)
+    def is_cuda_available(self):
+        return torch.cuda.is_available()
+
+    @DebugIt(show_args=True)
+    @command(dtype_in=CmdArgType.DevEncoded, dtype_out=[int, int, int, int])
+    def sample_detect(self, data):
+        encoding, image = data
+        width, height, dtype = encoding.split("/")
+        image = np.frombuffer(image, dtype=dtype).reshape(int(height), int(width))
+        bbox = self._sample_detect(image)
+        if bbox is None:
+            bbox = [0, 0, 0, 0]
+
+        return bbox
+
+    def _sample_detect(self, image):
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        result = self._model.predict(
+            source=_grayscale_to_rgb(image), max_det=1, conf=self._min_confidence, device=device
+        )
+        if len(result[0]):
+            result = result[0].boxes[0]
+            box = result.xyxy[0].detach().cpu().numpy()
+            # Round x0 and y0 down and x1, y1 up
+            bbox = [
+                int(np.floor(box[0])),
+                int(np.floor(box[1])),
+                int(np.ceil(box[2])),
+                int(np.ceil(box[3]))
+            ]
+            confidence = result.conf.detach().cpu().numpy()[0]
+        else:
+            bbox = None
+            confidence = 0
+
+        self.debug_stream("sample at: %s, confidence: %.3f", bbox, confidence)
+
+        return bbox
+
+    async def _stream_detect(self):
+        self._bboxes = []
+        last = None
+
+        async for image in self._receiver.subscribe():
+            bbox = self._sample_detect(image)
+            if bbox is None:
+                bbox = [0, 0, 0, 0]
+            else:
+                self._bboxes.append(bbox)
+            if self._sender and last != bbox:
+                print("send", bbox)
+                await self._sender.send_json({"sample-bbox": bbox})
+            last = bbox
+
+    @DebugIt()
+    @command()
+    async def stream_detect(self):
+        await self._process_stream(self._stream_detect())
+
+    @DebugIt(show_ret=True)
+    @command(dtype_out=[int, int, int, int])
+    async def get_maximum_rectangle(self):
+        if self._bboxes == []:
+            bbox = [0, 0, 0, 0]
+        else:
+            bboxes = np.array(self._bboxes)
+            bbox = [
+                np.min(bboxes[:, 0]),
+                np.min(bboxes[:, 1]),
+                np.max(bboxes[:, 2]),
+                np.max(bboxes[:, 3]),
+            ]
+
+        return bbox
+
+
+def _grayscale_to_rgb(image, percentile=0.1):
+    lower = np.percentile(image, percentile)
+    upper = np.percentile(image, 100 - percentile)
+
+    img_clipped = np.clip(image, lower, upper)
+    img_8bit = (((img_clipped - lower) / (upper - lower)) * 255).astype(np.uint8)
+
+    return np.dstack((img_8bit,) * 3)

--- a/concert/ext/tangoservers/sampledetect.py
+++ b/concert/ext/tangoservers/sampledetect.py
@@ -51,6 +51,7 @@ class SampleDetect(TangoRemoteProcessing):
         self._min_confidence = 0.25
         self._sender = None
         self._sending_port = 0
+        self._bboxes = []
 
     @InfoIt()
     async def get_model_path(self):
@@ -151,7 +152,6 @@ class SampleDetect(TangoRemoteProcessing):
             else:
                 self._bboxes.append(bbox)
             if self._sender and last != bbox:
-                print("send", bbox)
                 await self._sender.send_json({"sample-bbox": bbox})
             last = bbox
 
@@ -161,17 +161,18 @@ class SampleDetect(TangoRemoteProcessing):
         await self._process_stream(self._stream_detect())
 
     @DebugIt(show_ret=True)
-    @command(dtype_out=[int, int, int, int])
-    async def get_maximum_rectangle(self):
+    @command(dtype_in=float, dtype_out=[int, int, int, int])
+    async def get_maximum_rectangle(self, percentile):
         if self._bboxes == []:
             bbox = [0, 0, 0, 0]
         else:
             bboxes = np.array(self._bboxes)
+            minmax = np.percentile(bboxes, (percentile, 100 - percentile), axis=0)
             bbox = [
-                np.min(bboxes[:, 0]),
-                np.min(bboxes[:, 1]),
-                np.max(bboxes[:, 2]),
-                np.max(bboxes[:, 3]),
+                int(minmax[0, 0]),
+                int(minmax[0, 1]),
+                int(minmax[1, 2]),
+                int(minmax[1, 3]),
             ]
 
         return bbox

--- a/concert/ext/tangoservers/sampledetect.py
+++ b/concert/ext/tangoservers/sampledetect.py
@@ -1,6 +1,4 @@
-"""
-Tango server for benchmarking zmq transfers.
-"""
+"""Tango server for sample detection."""
 import numpy as np
 import torch
 import sys
@@ -16,9 +14,7 @@ except ImportError:
 
 
 class SampleDetect(TangoRemoteProcessing):
-    """
-    Device server for elmo_main.py-controller based
-    """
+    """Device server for detecting samples in projection images."""
 
     model_path = attribute(
         label="AI model path for sample detection",

--- a/concert/ext/tangoservers/walker.py
+++ b/concert/ext/tangoservers/walker.py
@@ -173,7 +173,6 @@ class TangoRemoteWalker(TangoRemoteProcessing):
     async def write_image(self, data):
         encoding, image = data
         name, width, height, num_channels, dtype = encoding.split(":")
-        print(name, width, height, dtype)
         num_channels = int(num_channels)
         shape = (int(height), int(width))
         if num_channels > 1:

--- a/concert/ext/tangoservers/walker.py
+++ b/concert/ext/tangoservers/walker.py
@@ -4,6 +4,7 @@ walker.py
 Implements a device server for file system traversal at remote host.
 """
 import logging
+import numpy as np
 import os
 from typing import Type, Dict, Tuple
 from tango import DebugIt, DevState, CmdArgType
@@ -14,6 +15,7 @@ from concert import writers
 from concert.storage import StorageError
 from concert.storage import DirectoryWalker
 from concert.ext.tangoservers.base import TangoRemoteProcessing
+from concert.writers import TiffWriter
 
 
 class TangoRemoteWalker(TangoRemoteProcessing):
@@ -165,6 +167,23 @@ class TangoRemoteWalker(TangoRemoteProcessing):
     )
     def exists(self, paths: str) -> bool:
         return os.path.exists(os.path.join(self._current, *paths))
+
+    @DebugIt(show_args=True)
+    @command(dtype_in=CmdArgType.DevEncoded)
+    async def write_image(self, data):
+        encoding, image = data
+        name, width, height, num_channels, dtype = encoding.split(":")
+        print(name, width, height, dtype)
+        num_channels = int(num_channels)
+        shape = (int(height), int(width))
+        if num_channels > 1:
+            shape += (num_channels,)
+        image = np.frombuffer(image, dtype=dtype).reshape(shape)
+        writer = TiffWriter(os.path.join(self._current, name), 0)
+        try:
+            writer.write(image)
+        finally:
+            writer.close()
 
     @DebugIt(show_args=True)
     @command(dtype_in=str)

--- a/concert/ext/ufo.py
+++ b/concert/ext/ufo.py
@@ -513,6 +513,8 @@ class GeneralBackprojectManager(Parameterizable):
     async def __ainit__(self, args, average_normalization=True, regions=None, copy_inputs=False):
         await super().__ainit__()
         self.args = args
+        self._orig_width = args.width
+        self._orig_height = args.height
         self.regions = regions
         self.copy_inputs = copy_inputs
         self.projections = None
@@ -822,6 +824,8 @@ class GeneralBackprojectManager(Parameterizable):
         self._flats_condition.done = False
         self._processing_task = None
         self._num_received_projections = self._num_processed_projections = 0
+        self.args.width = self._orig_width
+        self.args.height = self._orig_height
 
     @background
     async def update_darks(self, producer):

--- a/concert/ext/viewers.py
+++ b/concert/ext/viewers.py
@@ -409,7 +409,9 @@ class _ImageUpdaterBase(abc.ABC):
             self._loop = asyncio.get_event_loop()
         if self._receiver:
             self.unsubscribe()
-        self._receiver = ZmqReceiver(endpoint=address, reliable=False, rcvhwm=1)
+        self._receiver = self._loop.run_until_complete(
+            ZmqReceiver(endpoint=address, reliable=False, rcvhwm=1)
+        )
 
     def recv_array(self):
         available = self._loop.run_until_complete(self._receiver.is_message_available())
@@ -425,8 +427,11 @@ class _ImageUpdaterBase(abc.ABC):
         return available
 
     def unsubscribe(self, arg):
+        if not self._loop:
+            return
+
         if self._receiver:
-            self._receiver.close()
+            self._loop.run_until_complete(self._receiver.close())
         self._receiver = None
 
 

--- a/concert/ext/viewers.py
+++ b/concert/ext/viewers.py
@@ -12,6 +12,7 @@ from typing import Callable
 from concert.base import Parameterizable, Parameter
 from concert.coroutines.base import background, run_in_executor
 from concert.quantities import q
+from concert.helpers import ImageWithMetadata
 
 
 LOG = logging.getLogger(__name__)
@@ -142,13 +143,15 @@ class ViewerBase(Parameterizable):
         """Resume the viewer."""
         self._paused = False
 
-    def subscribe(self, address):
+    def subscribe(self, address, content):
+        if content not in ["image", "metadata"]:
+            raise ValueError("Content must be one of `image', `metadata'")
         self._ensure_updater_runs()
-        self._queue.put(('subscribe', address))
+        self._queue.put(('subscribe', (address, content)))
 
-    def unsubscribe(self):
+    def unsubscribe(self, address):
         if self._proc and self._proc.is_alive():
-            self._queue.put(('unsubscribe', None))
+            self._queue.put(('unsubscribe', address))
 
     def _ensure_updater_runs(self):
         """
@@ -333,6 +336,12 @@ class PyQtGraphViewer(ImageViewerBase):
         return _PyQtGraphUpdater(self._queue, limits=self._limits, title=self._title,
                                  show_refresh_rate=self._show_refresh_rate)
 
+    async def draw_rectangle(self, bbox):
+        self._queue.put(("sample-bbox", bbox))
+
+    async def clear_rectangle(self):
+        self._queue.put(("clear-bbox", None))
+
 
 class PyplotImageViewer(ImageViewerBase):
 
@@ -394,7 +403,7 @@ class _ImageUpdaterBase(abc.ABC):
 
     """Image updated base."""
     def __init__(self):
-        self._receiver = None
+        self._receivers = {}
         self._loop = None
         self.commands = {
             'subscribe': self.subscribe,
@@ -402,37 +411,57 @@ class _ImageUpdaterBase(abc.ABC):
             'title': self.change_title
         }
 
-    def subscribe(self, address):
+    def subscribe(self, data):
         import asyncio
         from concert.networking.base import ZmqReceiver
+
+        endpoint, content = data
+
         if not self._loop:
             self._loop = asyncio.get_event_loop()
-        if self._receiver:
-            self.unsubscribe()
-        self._receiver = self._loop.run_until_complete(
-            ZmqReceiver(endpoint=address, reliable=False, rcvhwm=1)
+        if endpoint in self._receivers:
+            self.unsubscribe(endpoint)
+        # Less polling time useful when there are multiple receivers
+        self._receivers[endpoint] = self._loop.run_until_complete(
+            ZmqReceiver(endpoint=endpoint, reliable=False, rcvhwm=1, polling_timeout=10 * q.ms)
         )
+        # Tag receiver to receive specific content
+        self._receivers[endpoint].content = content
 
     def recv_array(self):
-        available = self._loop.run_until_complete(self._receiver.is_message_available())
+        any_available = False
 
-        if available:
-            meta, image = self._loop.run_until_complete(self._receiver.receive_image())
-            if image is None:
-                # No actual image data available
-                available = False
-            else:
-                self.commands['image'](image)
+        for receiver in list(self._receivers.values()):
+            available = self._loop.run_until_complete(receiver.is_message_available())
 
-        return available
+            if available:
+                if receiver.content == "image":
+                    meta, image = self._loop.run_until_complete(receiver.receive_image())
+                    if image is None:
+                        # No actual image data available
+                        available = False
+                    else:
+                        self.commands['image'](image)
+                if receiver.content == "metadata":
+                    meta = self._loop.run_until_complete(receiver.receive_json())
+                    for key, value in meta.items():
+                        if key in self.commands:
+                            self.commands[key](value)
 
-    def unsubscribe(self, arg):
+            if available:
+                any_available = True
+
+        return any_available
+
+    def unsubscribe(self, endpoint):
         if not self._loop:
+            # We are not subscribed
             return
 
-        if self._receiver:
-            self._loop.run_until_complete(self._receiver.close())
-        self._receiver = None
+        if endpoint in self._receivers:
+            self._loop.run_until_complete(self._receivers[endpoint].close())
+
+        del self._receivers[endpoint]
 
 
 class _PyQtGraphUpdater(_ImageUpdaterBase):
@@ -448,6 +477,7 @@ class _PyQtGraphUpdater(_ImageUpdaterBase):
         self.show_refresh_rate = show_refresh_rate
         self.text = None
         self.plot = None
+        self.rect = None
         # main graphics window
         self.view = None
         self.last_text_time = time.perf_counter()
@@ -457,6 +487,8 @@ class _PyQtGraphUpdater(_ImageUpdaterBase):
                 'image': self.proces_image,
                 'clim': self.update_limits,
                 'show-fps': self.toggle_show_refresh_rate,
+                'sample-bbox': self.process_bbox,
+                'clear-bbox': self.clear_bbox,
             }
         )
 
@@ -468,7 +500,7 @@ class _PyQtGraphUpdater(_ImageUpdaterBase):
         except Empty:
             # Taking orders has priority, but if no order is available on the queu then receive an
             # image if subscribed
-            if self._receiver:
+            if self._receivers:
                 self.recv_array()
 
     def update_all(self, image):
@@ -559,6 +591,31 @@ class _PyQtGraphUpdater(_ImageUpdaterBase):
             if self.text:
                 self.view.removeItem(self.text)
             self.text = None
+
+    def process_bbox(self, bbox):
+        if not self.view:
+            # No image displayed yet
+            return
+
+        x_0 = bbox[0]
+        y_0 = bbox[1]
+        width = bbox[2] - bbox[0]
+        height = bbox[3] - bbox[1]
+
+        if self.rect is None:
+            import pyqtgraph as pg
+            from pyqtgraph.Qt import QtWidgets
+
+            self.rect = QtWidgets.QGraphicsRectItem(x_0, y_0, width, height)
+            self.rect.setPen(pg.mkPen('#5050D3', width=2))
+            self.view.addItem(self.rect)
+        else:
+            self.rect.setRect(x_0, y_0, width, height)
+
+    def clear_bbox(self, arg):
+        if self.view and self.rect:
+            self.view.removeItem(self.rect)
+            self.rect = None
 
     def change_title(self, title):
         self.title = title
@@ -802,7 +859,7 @@ class _PyplotImageUpdaterBase(_PyplotUpdaterBase, _ImageUpdaterBase):
 
     def on_empty(self):
         """Try to process image from a socket."""
-        if self._receiver:
+        if self._receivers:
             return self.recv_array()
         return False
 

--- a/concert/ext/viewers.py
+++ b/concert/ext/viewers.py
@@ -650,8 +650,10 @@ class _PyQtGraphUpdater(_ImageUpdaterBase):
         timer.timeout.connect(self.process)
         # 0 ms delay -> be as fast as possible
         timer.start(0)
-
-        app.exec_()
+        try:
+            app.exec()
+        except AttributeError:
+            app.exec_()
 
 
 class _PyplotUpdaterBase(abc.ABC):

--- a/concert/imageprocessing.py
+++ b/concert/imageprocessing.py
@@ -478,27 +478,37 @@ def filter_low_frequencies(data, fwhm=32.):
 def convert_image_to_nbit(image, num_bits=8, percentile=0.1, num_channels=1):
     """Convert *image* from any data type to an n-bit image. If *num_bits* <= 8, the output data
     type is np.uint8, if it is <= 16, it is np.uint16, if <= 32, it is np.uint32, if <= 64, it is
-    np.uint64.  Set black point to the gray value coresponding to *percentile* and set white point
-    to the gray value corresponding to 100 - *percenpercentile*. *num_channels* specifies how many
-    channels will the output have, which is the last dimension. If *num_channels* is 1, than the
+    np.uint64. Set black point to the gray value corresponding to *percentile* and set white point
+    to the gray value corresponding to 100 - *percentile*. *num_channels* specifies how many
+    channels the output has, which is the last dimension. If *num_channels* is 1, then the
     output shape is (height, width), if it is more than one it is (height, width, *num_channels*).
     You can create an RGB image by specifying num_bits=8 and num_channels=3, which leads to output
     shape (height, width, 3).
     """
     if num_bits <= 0 or num_bits > 64:
         raise ValueError("num_bits must be in the range [1, 64]")
-    elif num_bits <= 8:
+    if num_channels <= 0:
+        raise ValueError("num_channels must be greater than 0")
+    if num_bits <= 8:
         dtype = np.uint8
     elif num_bits <= 16:
         dtype = np.uint16
     elif num_bits <= 32:
         dtype = np.uint32
-    elif dtype <= 64:
+    else:
         dtype = np.uint64
 
     lower, upper = np.percentile(image, (percentile, 100 - percentile))
 
     img_clipped = np.clip(image, lower, upper)
-    converted = (((img_clipped - lower) / (upper - lower)) * (2 ** num_bits - 1)).astype(dtype)
+    if lower == upper:
+        converted = np.zeros(image.shape, dtype=dtype)
+    else:
+        maximum = 2 ** num_bits - 1
+        converted = np.zeros(image.shape, dtype=dtype)
+        middle = (img_clipped > lower) & (img_clipped < upper)
+        converted[middle] = (((img_clipped[middle] - lower) / (upper - lower))
+                             * maximum).astype(dtype)
+        converted[img_clipped >= upper] = maximum
 
     return np.dstack((converted,) * num_channels) if num_channels > 1 else converted

--- a/concert/networking/base.py
+++ b/concert/networking/base.py
@@ -220,7 +220,9 @@ class ZmqBase(AsyncObject, abc.ABC):
     is approximate.
     """
 
-    async def __ainit__(self, endpoint=None, reliable=True, polling_timeout=100 * q.ms, timeout=None):
+    async def __ainit__(
+        self, endpoint=None, reliable=True, polling_timeout=100 * q.ms, timeout=None
+    ):
         self._endpoint = endpoint
         self._poller = zmq.asyncio.Poller()
         self._polling_timeout = polling_timeout
@@ -474,6 +476,7 @@ class ZmqReceiver(ZmqBase):
             self._stopped.clear()
         else:
             self._stopped = asyncio.Event()
+        self._request_stop = False
 
         i = 0
         try:

--- a/concert/storage.py
+++ b/concert/storage.py
@@ -587,7 +587,7 @@ class RemoteDirectoryWalker(Walker):
 
         try:
             f = self.device.write_sequence("")
-            with ZmqSender(
+            async with await ZmqSender(
                 self._commdata.server_endpoint,
                 reliable=self._commdata.socket_type == zmq.PUSH,
                 sndhwm=self._commdata.sndhwm

--- a/concert/tests/unit/devices/test_camera.py
+++ b/concert/tests/unit/devices/test_camera.py
@@ -101,14 +101,14 @@ class TestDummyCamera(TestCase):
                 await self.camera.register_endpoint(
                     CommData("localhost", 8991 + i, "tcp", zmq.PUSH, 0)
                 )
-                receiver = ZmqReceiver(endpoint=f"tcp://localhost:{8991+i}")
+                receiver = await ZmqReceiver(endpoint=f"tcp://localhost:{8991+i}")
 
                 self.camera.set_mirror(mirrored)
                 self.camera.set_rotate(rotated)
                 async with self.camera.recording():
                     await self.camera.grab_send(1)
                     (metadata, image) = await receiver.receive_image()
-                receiver.close()
+                await receiver.close()
                 i += 1
                 meta = {"mirror": mirrored, "rotate": rotated}
                 np.testing.assert_equal(

--- a/concert/tests/unit/devices/test_device.py
+++ b/concert/tests/unit/devices/test_device.py
@@ -63,10 +63,11 @@ class TestDevice(TestCase):
 
     def test_str(self):
         from concert.session.utils import get_default_table
-        table = get_default_table(["Parameter", "Value"])
+        table = get_default_table(["Parameter", "Value", "Target", "lower", "upper",
+                                   "lower user", "upper user", "lower external", "upper external"])
         table.border = False
-        table.add_row(["readonly", "1"])
-        table.add_row(["writeonly", "N/A"])
+        table.add_row(["readonly", "1", "N/A", "", "", "", "", "", ""])
+        table.add_row(["writeonly", "N/A", "N/A", "", "", "", "", "", ""])
         self.assertEqual(str(self.device), table.get_string())
 
     async def test_context_manager(self):

--- a/concert/tests/unit/test_imageprocessing.py
+++ b/concert/tests/unit/test_imageprocessing.py
@@ -2,7 +2,12 @@ import numpy as np
 from concert.coroutines.base import async_generate
 from concert.devices.motors.dummy import ContinuousRotationMotor
 from concert.quantities import q
-from concert.imageprocessing import (compute_rotation_axis, normalize, find_sphere_centers)
+from concert.imageprocessing import (
+    compute_rotation_axis,
+    convert_image_to_nbit,
+    find_sphere_centers,
+    normalize,
+)
 from concert.measures import rotation_axis
 from concert.tests import suppressed_logging, slow, assert_almost_equal, TestCase
 from concert.tests.util.rotationaxis import SimulationCamera
@@ -62,6 +67,51 @@ def test_rescale():
 
     run_test(0, 1)
     run_test(-10, 47.5)
+
+
+def test_convert_image_to_nbit():
+    image = np.arange(100, dtype=np.float32).reshape(10, 10)
+
+    for num_bits, dtype in (
+        (1, np.uint8),
+        (8, np.uint8),
+        (9, np.uint16),
+        (16, np.uint16),
+        (17, np.uint32),
+        (32, np.uint32),
+        (33, np.uint64),
+        (64, np.uint64),
+    ):
+        converted = convert_image_to_nbit(image, num_bits=num_bits, percentile=0)
+        assert converted.dtype == dtype
+        assert converted.shape == image.shape
+        assert converted.min() == 0
+        assert converted.max() == 2 ** num_bits - 1
+
+
+def test_convert_image_to_nbit_percentile_and_channels():
+    image = np.array([[0, 1], [2, 100]], dtype=np.float32)
+    converted = convert_image_to_nbit(image, num_bits=8, percentile=25, num_channels=3)
+
+    assert converted.shape == (2, 2, 3)
+    assert converted.dtype == np.uint8
+    np.testing.assert_array_equal(converted[..., 0], converted[..., 1])
+    np.testing.assert_array_equal(converted[..., 1], converted[..., 2])
+    assert converted[0, 0, 0] == 0
+    assert converted[-1, -1, 0] == 255
+
+
+def test_convert_image_to_nbit_constant_and_invalid_arguments():
+    converted = convert_image_to_nbit(np.ones((2, 3)), num_bits=12, num_channels=2)
+    assert converted.shape == (2, 3, 2)
+    assert converted.dtype == np.uint16
+    assert not converted.any()
+
+    for num_bits in (0, 65):
+        with np.testing.assert_raises(ValueError):
+            convert_image_to_nbit(np.ones((2, 2)), num_bits=num_bits)
+    with np.testing.assert_raises(ValueError):
+        convert_image_to_nbit(np.ones((2, 2)), num_channels=0)
 
 
 @slow

--- a/concert/tests/unit/test_networking.py
+++ b/concert/tests/unit/test_networking.py
@@ -91,6 +91,11 @@ class TestZmq(TestCase):
         meta, image = await start(self.receiver.receive_image())
         np.testing.assert_equal(self.image, image)
 
+    async def test_send_receive_json(self):
+        payload = {"sample-bbox": [1, 2, 3, 4]}
+        await start(self.sender.send_json(payload))
+        self.assertEqual(await start(self.receiver.receive_json()), payload)
+
     async def test_publish_subscribe(self):
         # Make new ones
         await self.sender.close()
@@ -124,6 +129,38 @@ class TestZmq(TestCase):
 
         await f
         self.assertLessEqual(1, i)
+
+    async def test_receiver_stop_without_subscription(self):
+        await asyncio.wait_for(self.receiver.stop(), 1)
+        self.assertIsNone(self.receiver._stopped)
+
+    async def test_receiver_stop_requests_blocked_subscription(self):
+        async def consume():
+            async for _ in self.receiver.subscribe():
+                pass
+
+        subscription = start(consume())
+        await asyncio.sleep(0)
+        await asyncio.wait_for(self.receiver.stop(), 1)
+        await asyncio.wait_for(subscription, 1)
+
+        self.assertTrue(self.receiver._stopped.is_set())
+        self.assertFalse(self.receiver._request_stop)
+
+    async def test_receiver_can_subscribe_after_stop(self):
+        async def consume():
+            async for image in self.receiver.subscribe():
+                return image
+
+        first = start(consume())
+        await asyncio.sleep(0)
+        await asyncio.wait_for(self.receiver.stop(), 1)
+        await asyncio.wait_for(first, 1)
+
+        second = start(consume())
+        await self.sender.send_image(self.image)
+        image = await asyncio.wait_for(second, 1)
+        np.testing.assert_equal(image, self.image)
 
     async def test_broadcast_immediate_shutdown(self):
         sender, broadcast, receiver_1, receiver_2 = await setup_broadcaster()

--- a/concert/tests/unit/test_parameter.py
+++ b/concert/tests/unit/test_parameter.py
@@ -167,6 +167,41 @@ class UserLimitDevice(BaseDevice):
         self.upper_via_func = value
 
 
+class ParameterizableWithClassLimit(Parameterizable):
+    foo = Quantity(q.mm)
+
+    async def __ainit__(self):
+        self._foo = None
+        self._foo_lower_user = None
+        self._foo_upper_user = None
+        self._foo_upper_external = None
+        self._foo_lower_external = None
+        await super().__ainit__()
+
+    async def _get_foo(self):
+        return self._foo
+
+    async def _set_foo(self, value):
+        self._foo = value
+
+    async def _get_foo_lower_user_limit(self):
+        return self._foo_lower_user
+
+    async def _get_foo_upper_user_limit(self):
+        return self._foo_upper_user
+
+    async def _set_foo_lower_user_limit(self, value):
+        self._foo_lower_user = value
+
+    async def _set_foo_upper_user_limit(self, value):
+        self._foo_upper_user = value
+
+    async def _get_foo_upper_external_limit(self):
+        return self._foo_upper_external
+
+    async def _get_foo_lower_external_limit(self):
+        return self._foo_lower_external
+
 class AccessorCheckDevice(Parameterizable):
 
     foo = Quantity(q.m)
@@ -453,10 +488,55 @@ class TestQuantity(TestCase):
         self.assertEqual(await dev['foo'].get_upper(), 1 * q.mm)
         self.assertEqual(dev.upper_via_func, 1 * q.mm)
 
+    async def test_user_limits_fallback_to_internal_storage(self):
+        dev = await FooDevice(0 * q.mm)
+
+        self.assertIsNone(await dev['foo'].get_lower_user())
+        self.assertIsNone(await dev['foo'].get_upper_user())
+
+        await dev['foo'].set_lower(-2 * q.mm)
+        await dev['foo'].set_upper(2 * q.mm)
+        self.assertEqual(await dev['foo'].get_lower_user(), -2 * q.mm)
+        self.assertEqual(await dev['foo'].get_upper_user(), 2 * q.mm)
+
+    async def test_external_limits_default_to_none_when_not_implemented(self):
+        dev = await FooDevice(0 * q.mm)
+
+        self.assertIsNone(await dev['foo'].get_lower_external())
+        self.assertIsNone(await dev['foo'].get_upper_external())
+
     async def test_external_limits_info_table(self):
         dev = await ExternalLimitDevice(0 * q.mm)
         await dev['foo'].info_table
 
+
+class TestLimitsInClass(TestCase):
+    async def asyncSetUp(self):
+        self._device = await ParameterizableWithClassLimit()
+
+    async def test_user_limits(self):
+        await self._device['foo'].set_lower(-1 * q.mm)
+        await self._device['foo'].set_upper(1 * q.mm)
+        self.assertEqual(await self._device['foo'].get_lower_user(), -1 * q.mm)
+        self.assertEqual(await self._device['foo'].get_upper_user(), 1 * q.mm)
+
+        with self.assertRaises(SoftLimitError):
+            await self._device.set_foo(2*q.mm)
+
+        await self._device['foo'].set_lower(None)
+        await self._device['foo'].set_upper(None)
+        await self._device.set_foo(2*q.mm)
+
+    async def test_external_limits(self):
+        await self._device['foo'].set_lower(None)
+        await self._device['foo'].set_upper(None)
+        self.assertEqual(await self._device['foo'].get_lower(), None)
+        self.assertEqual(await self._device['foo'].get_upper(), None)
+
+        self._device._foo_upper_external = 5 * q.mm
+        self._device._foo_lower_external = -5 * q.mm
+        self.assertEqual(await self._device['foo'].get_lower(), -5 * q.mm)
+        self.assertEqual(await self._device['foo'].get_upper(), 5 * q.mm)
 
 class TestSelection(TestCase):
 

--- a/concert/tests/unit/test_sampledetect.py
+++ b/concert/tests/unit/test_sampledetect.py
@@ -1,0 +1,204 @@
+import asyncio
+import importlib
+import inspect
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from concert.experiments.addons.tango import SampleDetector as TangoSampleDetector
+
+importlib.import_module("concert.imageprocessing")
+
+
+@pytest.fixture
+def sampledetect_module(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.Tensor = type("Tensor", (), {})
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    ultralytics = types.ModuleType("ultralytics")
+
+    def make_model(path):
+        return ("model", path)
+
+    ultralytics.YOLO = make_model
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "ultralytics", ultralytics)
+    module_name = "concert.ext.tangoservers.sampledetect"
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+    yield module
+    sys.modules.pop(module_name, None)
+
+
+def unwrap(method):
+    return inspect.unwrap(method)
+
+
+def test_sample_detect_decodes_image_and_encodes_result(sampledetect_module):
+    image = np.arange(12, dtype=np.uint16).reshape(3, 4)
+    detected = []
+    device = types.SimpleNamespace(
+        _sample_detect=lambda value: detected.append(value.copy()) or ([1, 2, 4, 3], 0.8764)
+    )
+
+    result = unwrap(sampledetect_module.SampleDetect.sample_detect)(
+        device,
+        ("4/3/uint16", image.tobytes()),
+    )
+
+    np.testing.assert_array_equal(detected[0], image)
+    assert result == [1, 2, 4, 3, 876]
+
+
+def test_sample_detect_returns_zero_result_without_detection(sampledetect_module):
+    image = np.ones((2, 3), dtype=np.float32)
+    device = types.SimpleNamespace(_sample_detect=lambda value: (None, 0))
+
+    result = unwrap(sampledetect_module.SampleDetect.sample_detect)(
+        device,
+        ("3/2/float32", image.tobytes()),
+    )
+
+    assert result == [0, 0, 0, 0, 0]
+
+
+def test_sample_detect_model_prediction_rounds_bbox(sampledetect_module, monkeypatch):
+    class Tensor:
+        def __init__(self, value):
+            self.value = np.asarray(value)
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return self.value
+
+    box = types.SimpleNamespace(
+        xyxy=[Tensor([1.8, 2.2, 8.1, 9.9])],
+        conf=Tensor([0.75]),
+    )
+
+    class Prediction:
+        boxes = [box]
+
+        def __len__(self):
+            return len(self.boxes)
+
+    prediction = Prediction()
+    calls = []
+    model = types.SimpleNamespace(predict=lambda **kwargs: calls.append(kwargs) or [prediction])
+
+    def debug_stream(*args):
+        pass
+
+    detector = types.SimpleNamespace(
+        _model=model,
+        _min_confidence=0.4,
+        debug_stream=debug_stream,
+    )
+    converted = np.zeros((4, 5, 3), dtype=np.uint8)
+    monkeypatch.setattr(sampledetect_module, "convert_image_to_nbit", lambda *a, **kw: converted)
+    monkeypatch.setattr(sampledetect_module.torch.cuda, "is_available", lambda: True)
+
+    bbox, confidence = sampledetect_module.SampleDetect._sample_detect(
+        detector, np.ones((4, 5), dtype=np.uint16))
+
+    assert bbox == [1, 2, 9, 10]
+    assert confidence == pytest.approx(0.75)
+    assert calls == [{
+        "source": converted,
+        "max_det": 1,
+        "conf": 0.4,
+        "device": "cuda:0",
+    }]
+
+
+def test_sample_detect_model_prediction_without_box(sampledetect_module, monkeypatch):
+    class Prediction:
+        boxes = []
+
+        def __len__(self):
+            return 0
+
+    model = types.SimpleNamespace(predict=lambda **kwargs: [Prediction()])
+    detector = types.SimpleNamespace(
+        _model=model,
+        _min_confidence=0.25,
+        debug_stream=lambda *args: None,
+    )
+    monkeypatch.setattr(
+        sampledetect_module,
+        "convert_image_to_nbit",
+        lambda *a, **kw: np.zeros((2, 2, 3), dtype=np.uint8),
+    )
+
+    assert sampledetect_module.SampleDetect._sample_detect(
+        detector, np.ones((2, 2))) == (None, 0)
+
+
+def test_stream_detect_sends_only_bbox_changes(sampledetect_module):
+    async def subscribe():
+        for value in (1, 2, 3, 4):
+            yield np.array([[value]])
+
+    results = iter([
+        ([1, 2, 3, 4], 0.8),
+        ([1, 2, 3, 4], 0.7),
+        (None, 0),
+        ([2, 3, 4, 5], 0.9),
+    ])
+    sender = types.SimpleNamespace(send_json=AsyncMock())
+    detector = types.SimpleNamespace(
+        _receiver=types.SimpleNamespace(subscribe=subscribe),
+        _sender=sender,
+        _sample_detect=lambda image: next(results),
+        _bboxes=None,
+    )
+
+    asyncio.run(sampledetect_module.SampleDetect._stream_detect(detector))
+
+    assert detector._bboxes == [[1, 2, 3, 4], [1, 2, 3, 4], [2, 3, 4, 5]]
+    assert [call.args[0] for call in sender.send_json.await_args_list] == [
+        {"sample-bbox": [1, 2, 3, 4]},
+        {"sample-bbox": [0, 0, 0, 0]},
+        {"sample-bbox": [2, 3, 4, 5]},
+    ]
+
+
+def test_maximum_rectangle_uses_percentiles(sampledetect_module):
+    method = unwrap(sampledetect_module.SampleDetect.get_maximum_rectangle)
+    detector = types.SimpleNamespace(_bboxes=[])
+    assert asyncio.run(method(detector, 10)) == [0, 0, 0, 0]
+
+    detector._bboxes = [
+        [0, 10, 100, 110],
+        [10, 20, 90, 100],
+        [20, 30, 80, 90],
+    ]
+    assert asyncio.run(method(detector, 25)) == [5, 15, 95, 105]
+
+
+def test_tango_sample_detector_encodes_image_and_confidence():
+    image = np.arange(12, dtype=np.uint16).reshape(3, 4)
+    device = types.SimpleNamespace(
+        sample_detect=AsyncMock(return_value=[1, 2, 3, 4, 875]),
+        get_maximum_rectangle=AsyncMock(return_value=[2, 3, 8, 9]),
+    )
+    detector = types.SimpleNamespace(_device=device)
+
+    bbox, confidence = asyncio.run(TangoSampleDetector.detect(detector, image))
+
+    assert bbox == [1, 2, 3, 4]
+    assert confidence == pytest.approx(0.875)
+    encoding, blob = device.sample_detect.await_args.args[0]
+    assert encoding == "4/3/uint16"
+    np.testing.assert_array_equal(np.frombuffer(blob, dtype=np.uint16).reshape(3, 4), image)
+    assert asyncio.run(
+        TangoSampleDetector.get_maximum_rectangle(detector, 20)) == [2, 3, 8, 9]
+    device.get_maximum_rectangle.assert_awaited_once_with(20)

--- a/concert/tests/unit/test_walker.py
+++ b/concert/tests/unit/test_walker.py
@@ -2,10 +2,12 @@ import tempfile
 import shutil
 import numpy as np
 import os.path as op
+import tifffile
 from concert.coroutines.base import async_generate
-from concert.storage import DummyWalker, DirectoryWalker
+from concert.storage import DummyWalker, DirectoryWalker, RemoteDirectoryWalker
 from concert.storage import StorageError
 from concert.tests import TestCase
+from concert.tests.util.mocks import MockWalkerDevice
 
 
 class TestWalker(TestCase):
@@ -74,6 +76,21 @@ class TestDirectoryWalker(TestCase):
         await self.walker.write(async_generate([self.data]), dsetname='foo-{}.tif')
         self.assertTrue(op.exists(op.join(self.path, 'foo-0.tif')))
 
+    async def test_write_image(self):
+        image = np.arange(12, dtype=np.uint16).reshape(3, 4)
+        await self.walker.write_image(image, 'single.tif')
+
+        path = op.join(self.path, 'single.tif')
+        self.assertTrue(op.exists(path))
+        np.testing.assert_array_equal(tifffile.imread(path), image)
+
+        await self.walker.descend('inside')
+        await self.walker.write_image(image, 'nested.tif')
+        np.testing.assert_array_equal(
+            tifffile.imread(op.join(self.path, 'inside', 'nested.tif')),
+            image
+        )
+
     async def test_invalid_ascend(self):
         with self.assertRaises(StorageError):
             await self.walker.ascend()
@@ -104,3 +121,23 @@ class TestDirectoryWalker(TestCase):
         await test_raises('bar-}')
         await test_raises('bar-}{')
         await test_raises('bar-}{{}')
+
+
+class TestRemoteDirectoryWalker(TestCase):
+
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.device = MockWalkerDevice()
+        self.walker = await RemoteDirectoryWalker(device=self.device)
+
+    async def test_write_image(self):
+        image = np.arange(24, dtype=np.uint16).reshape(3, 4, 2)
+
+        await self.walker.write_image(image, "remote.tif")
+
+        encoding, blob = self.device.mock_device.write_image.await_args.args[0]
+        self.assertEqual(encoding, "remote.tif:4:3:2:uint16")
+        np.testing.assert_array_equal(
+            np.frombuffer(blob, dtype=np.uint16).reshape(3, 4, 2),
+            image
+        )

--- a/concert/tests/util/mocks.py
+++ b/concert/tests/util/mocks.py
@@ -42,6 +42,7 @@ class MockWalkerDevice:
         self._registered_log_paths = []
         self.mock_device.descend = mock.AsyncMock(side_effect=self._side_effect_descend)
         self.mock_device.ascend = mock.AsyncMock(side_effect=self._side_effect_ascend)
+        self.mock_device.write_image = mock.AsyncMock()
         self.mock_device.register_logger = mock.AsyncMock(
                 side_effect=self._side_effect_register_logger)  # noqa E126
         self.mock_device.deregister_logger = mock.AsyncMock(
@@ -88,6 +89,9 @@ class MockWalkerDevice:
 
     async def write_sequence(self, name: str) -> None:
         await self.mock_device.write_sequence(name=name)
+
+    async def write_image(self, data) -> None:
+        await self.mock_device.write_image(data)
 
     async def register_logger(self, args: Tuple[str, str, str]) -> str:
         return await self.mock_device.register_logger(args)

--- a/docs/devel/reference/core.rst
+++ b/docs/devel/reference/core.rst
@@ -47,7 +47,9 @@ Devices
     :show-inheritance:
     :members:
 
+.. autoclass:: concert.devices.dummy.DeviceWithClassGetter
 
+.. autoclass:: concert.devices.dummy.DeviceWithSetterInConstructor
 Asynchronous execution
 ----------------------
 

--- a/docs/devel/reference/ext.rst
+++ b/docs/devel/reference/ext.rst
@@ -20,3 +20,17 @@ Viewers
 
 .. automodule:: concert.ext.viewers
     :members:
+
+
+Sample detection
+----------------
+
+Remote sample detection is implemented by
+:class:`concert.experiments.addons.tango.SampleDetector` and the
+``TangoSampleDetect`` device server. The server accepts single encoded images
+or a ZMQ image stream, converts input to 8-bit three-channel data, and runs an
+Ultralytics YOLO model. Bounding-box changes may be published as JSON messages
+with the ``sample-bbox`` key.
+
+The server-side dependencies ``torch`` and ``ultralytics`` are optional and
+must be installed separately.

--- a/docs/user/topics/control.rst
+++ b/docs/user/topics/control.rst
@@ -111,9 +111,12 @@ one can do::
 Limits
 ------
 
-Limits allow you to restrict setting :class:`.Quantity` to a certain range. You
-can specify the :attr:`.Quantity.lower` and :attr:`.Quantity.upper` limits. Usage::
-
+Limits allow you to restrict setting :class:`.Quantity` to a certain range.
+Concert features two types of limits: *user_limits* and *external_limits*. User limits are set by the user and can be
+changed at any time.
+External limits are set by the device and cannot be changed by the user. Both types of limits are checked when setting
+a parameter value, and if the value is outside the limits, an error is raised.
+You can specify the :attr:`.Quantity.lower` and :attr:`.Quantity.upper` limits. Usage::
     # Blocking version
     motor['position'].lower = -10 * q.mm
     print(motor['position'].lower)
@@ -140,6 +143,15 @@ can specify the :attr:`.Quantity.lower` and :attr:`.Quantity.upper` limits. Usag
     motor['position'].lock_limits(permanent=True)
     # This will not work anymore until you restart the session
     motor['position'].unlock_limits()
+
+Reading :attr:`.Quantity.lower` and :attr:`.Quantity.upper` will give you the current limits that is the most narrow
+range between user and external limits. If you want to know the user and external limits separately, you can use
+:attr:`.Quantity.lower_external` and :attr:`.Quantity.upper_external`.
+Writing to :attr:`.Quantity.lower` and :attr:`.Quantity.upper` will set the user limits (:attr:`.Quantity.lower_user`
+and :attr:`.Quantity.upper_user`).
+An example how to implement the limits can be found in :class:`.DeviceWithClassGetter` and
+:class:`.DeviceWithSetterInConstructor` and in the documentation of
+:class:`.Parameterizable`.
 
 
 Emergency stop

--- a/docs/user/topics/experiments.rst
+++ b/docs/user/topics/experiments.rst
@@ -277,6 +277,47 @@ started, which can be done by::
     concert tango walker --port 2238
 
 
+Remote sample detection
+-----------------------
+
+:class:`~concert.experiments.addons.tango.SampleDetector` connects experiment
+acquisitions to a Tango sample-detection server. The server uses an Ultralytics
+YOLO model, so ``torch`` and ``ultralytics`` must be installed on the server
+machine. Configure the model before attaching the addon::
+
+    sample_endpoint = CommData(
+        "localhost",
+        port=8997,
+        socket_type=zmq.PUB,
+        sndhwm=1,
+    )
+    sample_device = get_tango_device(
+        f"{os.uname()[1]}:1239/concert/tango/sampledetect#dbase=no"
+    )
+    await sample_device.write_attribute("model_path", "/path/to/model.pt")
+    await sample_device.write_attribute("min_confidence", 0.25)
+
+    sample_detector = await tango_addons.SampleDetector(
+        ex,
+        sample_device,
+        sample_endpoint,
+        acquisitions=[ex.get_acquisition("radios")],
+    )
+
+The addon can also process an individual NumPy image directly::
+
+    bbox, confidence = await sample_detector.detect(image)
+
+``bbox`` is ``[x0, y0, x1, y1]`` in pixels. During streamed detection the
+server stores successful bounding boxes. After the acquisition, a robust
+rectangle can be obtained from their lower and upper percentiles::
+
+    bbox = await sample_detector.get_maximum_rectangle(percentile=10)
+
+Increasing ``percentile`` rejects more extreme detections. If no sample was
+detected, the returned rectangle is ``[0, 0, 0, 0]``.
+
+
 Addons
 ------
 

--- a/docs/user/topics/processing.rst
+++ b/docs/user/topics/processing.rst
@@ -134,3 +134,35 @@ does not change walker's path. The writing itself can then happen after the
     # create_writer ascends back so the writing itself can happen outside of the
     # with statement
     await writer
+
+To write one image with an explicit file name in the walker's current
+directory, use :meth:`~concert.storage.Walker.write_image`::
+
+    await walker.write_image(image, "preview.tif")
+
+This works for both :class:`~concert.storage.DirectoryWalker` and
+:class:`~concert.storage.RemoteDirectoryWalker`. The remote walker serializes
+the image shape and data type together with the pixel data and delegates the
+write to its Tango walker server.
+
+
+Converting images for display or inference
+==========================================
+
+:func:`~concert.imageprocessing.convert_image_to_nbit` maps an image to an
+unsigned integer representation with a selectable bit depth. Percentile
+clipping makes the conversion robust against outliers, and ``num_channels`` can
+be used to repeat a grayscale image into an RGB-like array::
+
+    from concert.imageprocessing import convert_image_to_nbit
+
+    preview = convert_image_to_nbit(
+        image,
+        num_bits=8,
+        percentile=0.1,
+        num_channels=3,
+    )
+
+The result above has shape ``(height, width, 3)`` and data type
+``numpy.uint8``. This is also the conversion used before passing detector
+images to the sample-detection model.

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
              'bin/concert-connect',
              'concert/ext/tangoservers/bin/TangoOnlineReconstruction',
              'concert/ext/tangoservers/bin/TangoRemoteWalker',
+             'concert/ext/tangoservers/bin/TangoSampleDetect',
              'concert/ext/tangoservers/bin/TangoBenchmarker',
              'concert/ext/tangoservers/bin/run_server_detached'],
     data_files=data_files,


### PR DESCRIPTION
## Wat's new

1. zmq's receiver can wait until `stop()` really stops
2. We can have `zmq.PUB/zmq.SUB` addons
3. We have `SampleDetector` addon
4. viewer can display a rectangle around an object


## Why so much

Adding sample detection addon which tracks the sample and at the end creates the larges bounding box does not need to be `zmq.PUSH/zmq.PULL`, but the "unreliable"  `zmq.PUB/zmq.SUB`, because we do not need to analyze _every_ image and thus drain resources. That in turn means that we have to be able to wait for `ZmqReceiver.stop()`, which turns **all zmq business to asyncio** and that means all classes `ZmqBase`, `ZmqReceiver`, ..., have to subclass `AsyncObject`. And that means, all code that uses them and their new asyncio functions had to be changed.

## TODOS

- [x] test underlying network changes - request stop of receiver mostly
- [x] test sample detection
- [x] test imageprocessing's image conversion
- [x] test storage's write_image
- [x] update docs


## Example session

```python
import asyncio
import logging
import os
import numpy as np
import zmq
from inspect import iscoroutinefunction
import concert
concert.require("0.34.0")

from concert.coroutines.base import background
from concert.devices.cameras.dummy import FileCamera
from concert.helpers import CommData
from concert.readers import TiffSequenceReader
from concert.quantities import q
from concert.networking.base import get_tango_device, ZmqReceiver
from concert.session.utils import ddoc, dstate, pdoc, code_of
from concert.ext.viewers import PyQtGraphViewer

LOG = logging.getLogger(__name__)
MULTIINSTANCE = False


async def detect(image):
    encoding = f"{image.shape[1]}/{image.shape[0]}/{image.dtype}"
    blob = image.tobytes()

    return await device.sample_detect((encoding, blob))


device = get_tango_device(f'{os.uname()[1]}:1239/concert/tango/sampledetect#dbase=no', timeout=1000 * q.s)
await device.write_attribute("model_path", "/mnt/fast3/best.pt")    # This is the AI model
viewer = await PyQtGraphViewer(show_refresh_rate=True)

com = CommData(host="localhost", port=18999, protocol="tcp", socket_type=zmq.PUB, sndhwm=1)
com_viewer = CommData(host="localhost", port=18998, protocol="tcp", socket_type=zmq.PUB, sndhwm=1)
camera = await FileCamera(YOU_REPLACE_WITH_PATH_TO_RADIOS)
await camera.register_endpoint(com)
await camera.register_endpoint(com_viewer)
await device.write_attribute("receiver_reliable", False)
await device.write_attribute("receiver_rcvhwm", 1)
await device.write_attribute("endpoint", com.client_endpoint)
if (await device.read_attribute("sending_port")).value != 19000:
    await device.write_attribute("sending_port", 19000)
await camera.start_recording()
viewer.subscribe("tcp://localhost:18998", "image")
viewer.subscribe("tcp://localhost:19000", "metadata")
```

## Example usage

```bash
sampledetect > f = device.stream_detect(); await camera.grab_send(1500)
sampledetect > await viewer.draw_rectangle(await device.get_maximum_rectangle())
```