### PR TITLE
Improve RunnableParameterizable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
               run: docker build -t concert-docker .
             - name: Setup Decentralized Infrastructure
               run: docker compose -f concert/tests/integration/scenarios/compose.yml up -d
+            - name: Sleep for 20 seconds
+              uses: GuillaumeFalourd/wait-sleep-action@v1
+              with:
+                time: '20' # for 20 seconds
             - name: Run Scenarios
               run: |
                 docker run \

--- a/concert/base.py
+++ b/concert/base.py
@@ -2,14 +2,21 @@
 """Core module Parameters"""
 import abc
 import asyncio
+import json
+import os
+import time
+
 import numpy as np
 import logging
 import functools
 import inspect
 import types
 from typing import List, Union
-from concert.helpers import memoize, get_state_from_awaitable
+
+import concert
+from concert.helpers import memoize, get_state_from_awaitable, get_basename
 from concert.coroutines.base import background, get_event_loop, run_in_loop, wait_until
+from concert.loghandler import AsyncLoggingHandlerCloser
 from concert.quantities import q
 
 
@@ -1354,19 +1361,216 @@ class Parameterizable(AsyncObject, abc.ABC):
 
 class RunnableParameterizable(Parameterizable):
     state = State()
+    separate_scans = Parameter()
+    name_fmt = Parameter()
+    iteration = Parameter()
+    current_name = Parameter(help="Name of the current iteration")
+    log_file_prefix = Parameter()
+    log_level = Selection(['critical', 'error', 'warning', 'info', 'debug'])
+    log_devices_at_start = Parameter()
+    log_devices_at_finish = Parameter()
 
-    async def __ainit__(self):
+
+    async def __ainit__(self, walker=None, separate_scans=True,
+                        name_fmt='scan_{:>04}'):
+        self._log_file_prefix = None
+        self.log = LOG
+        self._devices_to_log = {}
+        self._devices_to_log_optional = {}
+        self._log_devices_at_start = None
+        self._log_devices_at_finish = None
+        self.ready_to_prepare_next_outer_loop = asyncio.Event()
+
+        # 'ready_to_prepare_next_sample' was not the ideal name. We leave this for backward compatibility
+        self.ready_to_prepare_next_sample = self.ready_to_prepare_next_outer_loop
         await super().__ainit__()
         self._run_awaitable = None
+        self.walker = walker
+        await self.set_log_file_prefix("runnable")
+        await self.set_log_devices_at_start(True)
+        await self.set_log_devices_at_finish(True)
+        self._separate_scans = separate_scans
+        self._name_fmt = name_fmt
+        self._current_name = ""
+        self._iteration = 0
+
+        if separate_scans and walker:
+            # The data is not supposed to be overwritten, so find an iteration which
+            # hasn't been used yet
+            while await self.walker.exists(self._name_fmt.format(self._iteration)):
+                self._iteration += 1
+
 
     async def _get_state(self):
         return await get_state_from_awaitable(self._run_awaitable)
 
+    async def _get_iteration(self):
+        return self._iteration
+
+    async def _set_iteration(self, iteration):
+        self._iteration = iteration
+
+    async def _get_current_name(self):
+        return self._current_name
+
+    async def _get_separate_scans(self):
+        return self._separate_scans
+
+    async def _set_separate_scans(self, separate_scans):
+        self._separate_scans = separate_scans
+
+    async def _get_name_fmt(self):
+        return self._name_fmt
+
+    async def _set_name_fmt(self, fmt):
+        self._name_fmt = fmt
+
+
+    async def _set_log_devices_at_start(self, log):
+        self._log_devices_at_start = bool(log)
+
+    async def _get_log_devices_at_start(self):
+        return self._log_devices_at_start
+
+    async def _set_log_devices_at_finish(self, log):
+        self._log_devices_at_finish = bool(log)
+
+    async def _get_log_devices_at_finish(self):
+        return self._log_devices_at_finish
+
+    async def _get_log_level(self):
+        return logging.getLevelName(self.log.getEffectiveLevel()).lower()
+
+    async def _set_log_level(self, level):
+        self.log.setLevel(level.upper())
+
+    async def prepare(self):
+        """Gets executed before every experiment run."""
+        pass
+
+    async def finish(self):
+        """Gets executed after every experiment run."""
+        pass
+
+
+    def add_device_to_log(self, name: str, device: concert.devices.base.Device, optional=False):
+        """
+        Add a device to log.
+
+        :param name: Name of the device
+        :param device: Device to log
+        :param optional: If True, an exception when trying to log the device will not cause an
+            error.
+        """
+        if optional:
+            self._devices_to_log_optional[name] = device
+        else:
+            self._devices_to_log[name] = device
+
+    async def _prepare_metadata_str(self) -> str:
+        """Prepares the experiment metadata to be written to file. It is
+        a dictionary which potentially encapsulates one or more dictionary
+        objects.
+        """
+        metadata = {}
+        exp_params = {}
+        for param in self:
+            exp_params[param.name] = str(await param.get())
+        metadata["experiment"] = exp_params
+        for name, device in self._devices_to_log.items():
+            device_data = {}
+            for param in device:
+                device_data[param.name] = str(await param.get())
+            metadata[name] = device_data
+
+        for name, device in self._devices_to_log_optional.items():
+            device_data = {}
+            for param in device:
+                try:
+                    device_data[param.name] = str(await param.get())
+                except Exception as e:
+                    self.log.info(f"Error while logging optional device {name}")
+                    self.log.info(e)
+            metadata[name] = device_data
+        return json.dumps(metadata, indent=4)
+
+
+    async def _get_log_file_prefix(self):
+        return self._log_file_prefix
+
+    async def _set_log_file_prefix(self, prefix: str):
+        self._log_file_prefix = str(prefix)
+
+
+    async def early_prepare(self):
+        """
+        Function that is called at first in the run() BEFORE the first logging starts.
+
+        This can be used if devices need to be configured in a way that they produce proper logging results.
+        """
+        pass
+
+    async def late_finish(self):
+        pass
+
     @background
     @check(source=['standby', 'error', 'cancelled'], target=['standby', 'cancelled'])
     async def run(self):
-        self._run_awaitable = self._run()
-        await self._run_awaitable
+        self.ready_to_prepare_next_outer_loop.clear()
+        await self.early_prepare()
+        start_time = time.time()
+        handler = None
+        iteration = await self.get_iteration()
+        separate_scans = await self.get_separate_scans()
+
+        if self.walker:
+            if separate_scans:
+                await self.walker.descend((await self.get_name_fmt()).format(iteration))
+            if os.path.exists(await self.walker.get_current()):
+                handler: AsyncLoggingHandlerCloser = await self.walker.register_logger(
+                    logger_name=self.__class__.__name__,
+                    log_level=logging.NOTSET,
+                    file_name=f"{await self.get_log_file_prefix()}.log"
+                )
+                self.log.addHandler(handler)
+                if await self.get_log_devices_at_start():
+                    log_metadata: str = await self._prepare_metadata_str()
+                    await self.walker.log_to_json(payload=log_metadata,
+                                                  filename=f"{await self.get_log_file_prefix()}_start.json")
+            self._current_name = get_basename(await self.walker.get_current())
+        self.log.info(await self.info_table)
+        for name, device in self._devices_to_log.items():
+            self.log.info(f"Device {name}:")
+            self.log.info(await device.info_table)
+        LOG.debug('Run with iteration %d start', iteration)
+
+        try:
+            await self.prepare()
+            self._run_awaitable = self._run()
+            await self._run_awaitable
+        finally:
+            try:
+                await self.finish()
+                if self.walker:
+                    if await self.get_log_devices_at_finish():
+                        log_metadata: str = await self._prepare_metadata_str()
+                        await self.walker.log_to_json(payload=log_metadata,
+                                                      filename=f"{await self.get_log_file_prefix()}_finish.json")
+                await self.late_finish()
+            except Exception as e:
+                LOG.warning(f"Error `{e}' while finalizing run().")
+                raise StateError('error', msg=str(e))
+            finally:
+                self.ready_to_prepare_next_sample.set()
+                if separate_scans and self.walker:
+                    await self.walker.ascend()
+                LOG.debug('Experiment iteration %d duration: %.2f s',
+                          iteration, time.time() - start_time)
+                if handler:
+                    await handler.aclose()
+                    self.log.removeHandler(handler)
+                await self.set_iteration(iteration + 1)
+
 
     @abc.abstractmethod
     @background

--- a/concert/base.py
+++ b/concert/base.py
@@ -1832,6 +1832,7 @@ class RunnableParameterizable(Parameterizable):
         handler = None
         descended = False
         lifecycle_started = False
+        finalization_error = None
         iteration = await self.get_iteration()
         separate_scans = await self.get_separate_scans()
 
@@ -1879,7 +1880,7 @@ class RunnableParameterizable(Parameterizable):
                     await self.late_finish()
                 except Exception as e:
                     LOG.warning(f"Error `{e}' while finalizing run().")
-                    raise StateError('error', msg=str(e))
+                    finalization_error = StateError('error', msg=str(e))
             try:
                 self.ready_to_prepare_next_sample.set()
                 if descended:
@@ -1893,7 +1894,10 @@ class RunnableParameterizable(Parameterizable):
                     await self.set_iteration(iteration + 1)
             except Exception as e:
                 LOG.warning(f"Error `{e}' while cleaning up run().")
-                raise StateError('error', msg=str(e))
+                if finalization_error is None:
+                    finalization_error = StateError('error', msg=str(e))
+            if finalization_error is not None:
+                raise finalization_error
 
 
     @abc.abstractmethod

--- a/concert/base.py
+++ b/concert/base.py
@@ -2,15 +2,23 @@
 """Core module Parameters"""
 import abc
 import asyncio
+import json
+import os
+import time
+
 import numpy as np
 import logging
 import functools
 import inspect
 import types
 from typing import List, Union
-from concert.helpers import memoize, get_state_from_awaitable
+
+import concert
+from concert.helpers import memoize, get_state_from_awaitable, get_basename
 from concert.coroutines.base import background, get_event_loop, run_in_loop, wait_until
+from concert.loghandler import AsyncLoggingHandlerCloser
 from concert.quantities import q
+
 
 LOG = logging.getLogger(__name__)
 _RUN_IN_LOOP_ERR_TMPL = "Someone is trying to use `{}' " \
@@ -70,7 +78,6 @@ def _find_object_by_name(instance):
     """Find variable name by *instance*. This is supposed to be used only in the
     :meth:`.Parameter.__set__`.
     """
-
     def _is_name_ok(instance_name):
         return instance_name and instance_name not in ['instance', 'self']
 
@@ -228,7 +235,6 @@ def transition(immediate=None, target=None, state_name='state'):
     and cleanup logic must take place in the callable to be wrapped.
     *state_name* can be used to define the state if multiple states are used.
     """
-
     def wrapped(func):
         @functools.wraps(func)
         async def call_func(instance, *args, **kwargs):
@@ -272,7 +278,6 @@ def check(source: Union[str, List[str]] = '*', target: Union[str, List[str]] = '
     target states.
     *state_name* can be used to define the state if multiple states are used.
     """
-
     async def check_now(instance, allowed_states, state_str):
         state = await instance[state_name].get()
         if state not in allowed_states and '*' not in allowed_states:
@@ -1667,20 +1672,229 @@ class RunnableParameterizable(Parameterizable):
     """A parameter collection whose asynchronous operation can be run and monitored."""
 
     state = State()
+    separate_scans = Parameter()
+    name_fmt = Parameter()
+    iteration = Parameter()
+    current_name = Parameter(help="Name of the current iteration")
+    log_file_prefix = Parameter()
+    log_level = Selection(['critical', 'error', 'warning', 'info', 'debug'])
+    log_devices_at_start = Parameter()
+    log_devices_at_finish = Parameter()
 
-    async def __ainit__(self, **kwargs):
+
+    async def __ainit__(self, walker=None, separate_scans=True,
+                        name_fmt='scan_{:>04}', **kwargs):
+        self._log_file_prefix = None
+        self.log = LOG
+        self._devices_to_log = {}
+        self._devices_to_log_optional = {}
+        self._log_devices_at_start = None
+        self._log_devices_at_finish = None
+        self.ready_to_prepare_next_outer_loop = asyncio.Event()
+
+        # 'ready_to_prepare_next_sample' was not the ideal name. We leave this for backward compatibility
+        self.ready_to_prepare_next_sample = self.ready_to_prepare_next_outer_loop
         await super().__ainit__(**kwargs)
         self._run_awaitable = None
+        self.walker = walker
+        await self.set_log_file_prefix("runnable")
+        await self.set_log_devices_at_start(True)
+        await self.set_log_devices_at_finish(True)
+        self._separate_scans = separate_scans
+        self._name_fmt = name_fmt
+        self._current_name = ""
+        self._iteration = 0
+
+        if separate_scans and walker:
+            # The data is not supposed to be overwritten, so find an iteration which
+            # hasn't been used yet
+            while await self.walker.exists(self._name_fmt.format(self._iteration)):
+                self._iteration += 1
+
 
     async def _get_state(self):
         return await get_state_from_awaitable(self._run_awaitable)
 
+    async def _get_iteration(self):
+        return self._iteration
+
+    async def _set_iteration(self, iteration):
+        self._iteration = iteration
+
+    async def _get_current_name(self):
+        return self._current_name
+
+    async def _get_separate_scans(self):
+        return self._separate_scans
+
+    async def _set_separate_scans(self, separate_scans):
+        self._separate_scans = separate_scans
+
+    async def _get_name_fmt(self):
+        return self._name_fmt
+
+    async def _set_name_fmt(self, fmt):
+        self._name_fmt = fmt
+
+
+    async def _set_log_devices_at_start(self, log):
+        self._log_devices_at_start = bool(log)
+
+    async def _get_log_devices_at_start(self):
+        return self._log_devices_at_start
+
+    async def _set_log_devices_at_finish(self, log):
+        self._log_devices_at_finish = bool(log)
+
+    async def _get_log_devices_at_finish(self):
+        return self._log_devices_at_finish
+
+    async def _get_log_level(self):
+        return logging.getLevelName(self.log.getEffectiveLevel()).lower()
+
+    async def _set_log_level(self, level):
+        self.log.setLevel(level.upper())
+
+    async def prepare(self):
+        """Gets executed before every experiment run."""
+        pass
+
+    async def finish(self):
+        """Gets executed after every experiment run."""
+        pass
+
+
+    def add_device_to_log(self, name: str, device: 'concert.devices.base.Device', optional=False):
+        """
+        Add a device to log.
+
+        :param name: Name of the device
+        :param device: Device to log
+        :param optional: If True, an exception when trying to log the device will not cause an
+            error.
+        """
+        if optional:
+            self._devices_to_log_optional[name] = device
+        else:
+            self._devices_to_log[name] = device
+
+    async def _prepare_metadata_str(self) -> str:
+        """Prepares the experiment metadata to be written to file. It is
+        a dictionary which potentially encapsulates one or more dictionary
+        objects.
+        """
+        metadata = {}
+        exp_params = {}
+        for param in self:
+            exp_params[param.name] = str(await param.get())
+        metadata["experiment"] = exp_params
+        for name, device in self._devices_to_log.items():
+            device_data = {}
+            for param in device:
+                device_data[param.name] = str(await param.get())
+            metadata[name] = device_data
+
+        for name, device in self._devices_to_log_optional.items():
+            device_data = {}
+            for param in device:
+                try:
+                    device_data[param.name] = str(await param.get())
+                except Exception as e:
+                    self.log.info(f"Error while logging optional device {name}")
+                    self.log.info(e)
+            metadata[name] = device_data
+        return json.dumps(metadata, indent=4)
+
+
+    async def _get_log_file_prefix(self):
+        return self._log_file_prefix
+
+    async def _set_log_file_prefix(self, prefix: str):
+        self._log_file_prefix = str(prefix)
+
+
+    async def early_prepare(self):
+        """
+        Function that is called at first in the run() BEFORE the first logging starts.
+
+        This can be used if devices need to be configured in a way that they produce proper logging results.
+        """
+        pass
+
+    async def late_finish(self):
+        pass
+
     @background
     @check(source=['standby', 'error', 'cancelled'], target=['standby', 'cancelled'])
     async def run(self):
-        """Run :meth:`_run` while exposing its progress through ``state``."""
-        self._run_awaitable = self._run()
-        await self._run_awaitable
+        self.ready_to_prepare_next_outer_loop.clear()
+        start_time = time.time()
+        handler = None
+        descended = False
+        lifecycle_started = False
+        iteration = await self.get_iteration()
+        separate_scans = await self.get_separate_scans()
+
+        try:
+            await self.early_prepare()
+            if self.walker:
+                if separate_scans:
+                    await self.walker.descend((await self.get_name_fmt()).format(iteration))
+                    descended = True
+                if os.path.exists(await self.walker.get_current()):
+                    handler: AsyncLoggingHandlerCloser = await self.walker.register_logger(
+                        logger_name=self.__class__.__name__,
+                        log_level=logging.NOTSET,
+                        file_name=f"{await self.get_log_file_prefix()}.log"
+                    )
+                    self.log.addHandler(handler)
+                    if await self.get_log_devices_at_start():
+                        log_metadata: str = await self._prepare_metadata_str()
+                        await self.walker.log_to_json(
+                            payload=log_metadata,
+                            filename=f"{await self.get_log_file_prefix()}_start.json"
+                        )
+                self._current_name = get_basename(await self.walker.get_current())
+            self.log.info(await self.info_table)
+            for name, device in self._devices_to_log.items():
+                self.log.info(f"Device {name}:")
+                self.log.info(await device.info_table)
+            LOG.debug('Run with iteration %d start', iteration)
+
+            lifecycle_started = True
+            await self.prepare()
+            self._run_awaitable = self._run()
+            await self._run_awaitable
+        finally:
+            if lifecycle_started:
+                try:
+                    await self.finish()
+                    if self.walker:
+                        if await self.get_log_devices_at_finish():
+                            log_metadata: str = await self._prepare_metadata_str()
+                            await self.walker.log_to_json(
+                                payload=log_metadata,
+                                filename=f"{await self.get_log_file_prefix()}_finish.json"
+                            )
+                    await self.late_finish()
+                except Exception as e:
+                    LOG.warning(f"Error `{e}' while finalizing run().")
+                    raise StateError('error', msg=str(e))
+            try:
+                self.ready_to_prepare_next_sample.set()
+                if descended:
+                    await self.walker.ascend()
+                LOG.debug('Experiment iteration %d duration: %.2f s',
+                          iteration, time.time() - start_time)
+                if handler:
+                    self.log.removeHandler(handler)
+                    await handler.aclose()
+                if lifecycle_started:
+                    await self.set_iteration(iteration + 1)
+            except Exception as e:
+                LOG.warning(f"Error `{e}' while cleaning up run().")
+                raise StateError('error', msg=str(e))
+
 
     @abc.abstractmethod
     @background

--- a/concert/devices/__init__.py
+++ b/concert/devices/__init__.py
@@ -1,1 +1,3 @@
 """__init__.py"""
+
+from concert.devices import base

--- a/concert/directors/base.py
+++ b/concert/directors/base.py
@@ -3,8 +3,6 @@ import logging
 from abc import abstractmethod
 
 from concert.base import background, Parameter, StateError, Selection, RunnableParameterizable
-from concert.helpers import get_state_from_awaitable
-from concert.loghandler import AsyncLoggingHandlerCloser
 
 LOG = logging.getLogger(__name__)
 
@@ -18,7 +16,8 @@ class Director(RunnableParameterizable):
     current_iteration_name = Parameter()
     log_level = Selection(['critical', 'error', 'warning', 'info', 'debug'])
 
-    async def __ainit__(self, experiment):
+    async def __ainit__(self, experiment, walker=None, separate_scans=True,
+                        name_fmt='director_scan_{:>04}'):
         """
         :param experiment: Experiment that is run. If the experiment features a
             'ready_to_prepare_next_sample' event (asyncio.Event) this will be waited within the
@@ -33,23 +32,16 @@ class Director(RunnableParameterizable):
         self._run_event = asyncio.Event()
         # Let us run by default
         self._run_event.set()
-        self._iteration = 0
-        self.log = LOG
-        self.log.setLevel("INFO")
-        await super().__ainit__()
+        await super().__ainit__(walker=walker, separate_scans=separate_scans,
+                        name_fmt=name_fmt)
+        await self.set_log_file_prefix("director")
 
     async def _get_state(self):
-        state = await get_state_from_awaitable(self._run_awaitable)
+        state = await super().get_state()
         if state == 'running' and not self._run_event.is_set():
             return 'paused'
         else:
             return state
-
-    async def _get_log_level(self):
-        return logging.getLevelName(self.log.getEffectiveLevel()).lower()
-
-    async def _set_log_level(self, level):
-        self.log.setLevel(level.upper())
 
     @abstractmethod
     async def _prepare_run(self, iteration: int):
@@ -92,18 +84,7 @@ class Director(RunnableParameterizable):
     async def _run(self):
         await self._experiment['separate_scans'].stash()
         await self._experiment.set_separate_scans(False)
-        handler = None
         try:
-            if self._experiment.walker:
-                handler: AsyncLoggingHandlerCloser = await self._experiment.walker.register_logger(
-                    logger_name=self.__class__.__name__,
-                    log_level=logging.NOTSET,
-                    file_name="director.log"
-                )
-                self.log.addHandler(handler)
-            self.log.info(await self.info_table)
-
-            await self.prepare()
             # prepare first iteration
             self._iteration = 0
             await self._prepare_run(self._iteration)
@@ -114,13 +95,12 @@ class Director(RunnableParameterizable):
 
                 await self._experiment.walker.descend(await self.get_iteration_name(iteration))
                 exp_run = self._experiment.run()
-                sample_name = await self.get_iteration_name(iteration)
-                self._experiment.log.info(f"Sample name: {sample_name}")
-                self._experiment.log.info(await self.info_table)
+                iteration_name = await self.get_iteration_name(iteration)
+                self._experiment.log.info(f"Iteration name: {iteration_name}")
 
                 # Note: exp_run and self._experiment.ready_to_prepare_next_sample.wait() finish
                 # at the same time, if the user does not implement ready_to_prepare_next_sample.
-                await self._experiment.ready_to_prepare_next_sample.wait()
+                await self._experiment.ready_to_prepare_next_outer_loop.wait()
                 await self._prepare_next_run()
                 try:
                     await exp_run
@@ -144,11 +124,7 @@ class Director(RunnableParameterizable):
             LOG.warning('Experiment director cancelled by keyboard interrupt')
             raise
         finally:
-            if handler:
-                await handler.aclose()
-                self.log.removeHandler(handler)
             await self._experiment['separate_scans'].restore()
-            await self.finish()
 
     async def _get_current_iteration(self) -> int:
         return self._iteration
@@ -167,9 +143,3 @@ class Director(RunnableParameterizable):
         Resumes a currently paused director run.
         """
         self._run_event.set()
-
-    async def prepare(self):
-        pass
-
-    async def finish(self):
-        pass

--- a/concert/directors/base.py
+++ b/concert/directors/base.py
@@ -3,8 +3,6 @@ import logging
 from abc import abstractmethod
 
 from concert.base import background, Parameter, StateError, Selection, RunnableParameterizable
-from concert.helpers import get_state_from_awaitable
-from concert.loghandler import AsyncLoggingHandlerCloser
 
 LOG = logging.getLogger(__name__)
 
@@ -18,7 +16,8 @@ class Director(RunnableParameterizable):
     current_iteration_name = Parameter()
     log_level = Selection(['critical', 'error', 'warning', 'info', 'debug'])
 
-    async def __ainit__(self, *, experiment, **kwargs):
+    async def __ainit__(self, experiment, walker=None, separate_scans=True,
+                        name_fmt='director_scan_{:>04}', **kwargs):
         """
         :param experiment: Experiment that is run. If the experiment features a
             'ready_to_prepare_next_sample' event (asyncio.Event) this will be waited within the
@@ -33,23 +32,16 @@ class Director(RunnableParameterizable):
         self._run_event = asyncio.Event()
         # Let us run by default
         self._run_event.set()
-        self._iteration = 0
-        self.log = LOG
-        self.log.setLevel("INFO")
-        await super().__ainit__(**kwargs)
+        await super().__ainit__(walker=walker, separate_scans=separate_scans,
+                        name_fmt=name_fmt, **kwargs)
+        await self.set_log_file_prefix("director")
 
     async def _get_state(self):
-        state = await get_state_from_awaitable(self._run_awaitable)
+        state = await super()._get_state()
         if state == 'running' and not self._run_event.is_set():
             return 'paused'
         else:
             return state
-
-    async def _get_log_level(self):
-        return logging.getLevelName(self.log.getEffectiveLevel()).lower()
-
-    async def _set_log_level(self, level):
-        self.log.setLevel(level.upper())
 
     @abstractmethod
     async def _prepare_run(self, iteration: int):
@@ -92,18 +84,7 @@ class Director(RunnableParameterizable):
     async def _run(self):
         await self._experiment['separate_scans'].stash()
         await self._experiment.set_separate_scans(False)
-        handler = None
         try:
-            if self._experiment.walker:
-                handler: AsyncLoggingHandlerCloser = await self._experiment.walker.register_logger(
-                    logger_name=self.__class__.__name__,
-                    log_level=logging.NOTSET,
-                    file_name="director.log"
-                )
-                self.log.addHandler(handler)
-            self.log.info(await self.info_table)
-
-            await self.prepare()
             # prepare first iteration
             self._iteration = 0
             await self._prepare_run(self._iteration)
@@ -114,13 +95,12 @@ class Director(RunnableParameterizable):
 
                 await self._experiment.walker.descend(await self.get_iteration_name(iteration))
                 exp_run = self._experiment.run()
-                sample_name = await self.get_iteration_name(iteration)
-                self._experiment.log.info(f"Sample name: {sample_name}")
-                self._experiment.log.info(await self.info_table)
+                iteration_name = await self.get_iteration_name(iteration)
+                self._experiment.log.info(f"Iteration name: {iteration_name}")
 
                 # Note: exp_run and self._experiment.ready_to_prepare_next_sample.wait() finish
                 # at the same time, if the user does not implement ready_to_prepare_next_sample.
-                await self._experiment.ready_to_prepare_next_sample.wait()
+                await self._experiment.ready_to_prepare_next_outer_loop.wait()
                 await self._prepare_next_run()
                 try:
                     await exp_run
@@ -144,11 +124,7 @@ class Director(RunnableParameterizable):
             LOG.warning('Experiment director cancelled by keyboard interrupt')
             raise
         finally:
-            if handler:
-                await handler.aclose()
-                self.log.removeHandler(handler)
             await self._experiment['separate_scans'].restore()
-            await self.finish()
 
     async def _get_current_iteration(self) -> int:
         return self._iteration
@@ -167,9 +143,3 @@ class Director(RunnableParameterizable):
         Resumes a currently paused director run.
         """
         self._run_event.set()
-
-    async def prepare(self):
-        pass
-
-    async def finish(self):
-        pass

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -264,127 +264,13 @@ class Experiment(RunnableParameterizable):
 
     """
 
-    iteration = Parameter()
-    separate_scans = Parameter()
-    name_fmt = Parameter()
-    current_name = Parameter(help="Name of the current iteration")
-    log_level = Selection(['critical', 'error', 'warning', 'info', 'debug'])
-    log_devices_at_start = Parameter()
-    log_devices_at_finish = Parameter()
-
     async def __ainit__(self, acquisitions, walker=None, separate_scans=True,
                         name_fmt='scan_{:>04}'):
         self._acquisitions = []
         for acquisition in acquisitions:
             self.add(acquisition)
-        self.walker = walker
-        self._separate_scans = separate_scans
-        self._name_fmt = name_fmt
-        self._current_name = ""
-        self._iteration = 0
-        self.log = LOG
-        self._devices_to_log = {}
-        self._devices_to_log_optional = {}
-        self._log_devices_at_start = None
-        self._log_devices_at_finish = None
-        self.ready_to_prepare_next_sample = asyncio.Event()
-        await super().__ainit__()
-        await self.set_log_devices_at_start(True)
-        await self.set_log_devices_at_finish(True)
-
-        if separate_scans and walker:
-            # The data is not supposed to be overwritten, so find an iteration which
-            # hasn't been used yet
-            while await self.walker.exists(self._name_fmt.format(self._iteration)):
-                self._iteration += 1
-
-    async def _set_log_devices_at_start(self, log):
-        self._log_devices_at_start = bool(log)
-
-    async def _get_log_devices_at_start(self):
-        return self._log_devices_at_start
-
-    async def _set_log_devices_at_finish(self, log):
-        self._log_devices_at_finish = bool(log)
-
-    async def _get_log_devices_at_finish(self):
-        return self._log_devices_at_finish
-
-    def add_device_to_log(self, name: str, device: concert.devices.base.Device, optional=False):
-        """
-        Add a device to log.
-
-        :param name: Name of the device
-        :param device: Device to log
-        :param optional: If True, an exception when trying to log the device will not cause an
-            error.
-        """
-        if optional:
-            self._devices_to_log_optional[name] = device
-        else:
-            self._devices_to_log[name] = device
-
-    async def _prepare_metadata_str(self) -> str:
-        """Prepares the experiment metadata to be written to file. It is
-        a dictionary which potentially encapsulates one or more dictionary
-        objects.
-        """
-        metadata = {}
-        exp_params = {}
-        for param in self:
-            exp_params[param.name] = str(await param.get())
-        metadata["experiment"] = exp_params
-        for name, device in self._devices_to_log.items():
-            device_data = {}
-            for param in device:
-                device_data[param.name] = str(await param.get())
-            metadata[name] = device_data
-
-        for name, device in self._devices_to_log_optional.items():
-            device_data = {}
-            for param in device:
-                try:
-                    device_data[param.name] = str(await param.get())
-                except Exception as e:
-                    self.log.info(f"Error while logging optional device {name}")
-                    self.log.info(e)
-            metadata[name] = device_data
-        return json.dumps(metadata, indent=4)
-
-    async def _get_iteration(self):
-        return self._iteration
-
-    async def _set_iteration(self, iteration):
-        self._iteration = iteration
-
-    async def _get_current_name(self):
-        return self._current_name
-
-    async def _get_separate_scans(self):
-        return self._separate_scans
-
-    async def _set_separate_scans(self, separate_scans):
-        self._separate_scans = separate_scans
-
-    async def _get_name_fmt(self):
-        return self._name_fmt
-
-    async def _set_name_fmt(self, fmt):
-        self._name_fmt = fmt
-
-    async def _get_log_level(self):
-        return logging.getLevelName(self.log.getEffectiveLevel()).lower()
-
-    async def _set_log_level(self, level):
-        self.log.setLevel(level.upper())
-
-    async def prepare(self):
-        """Gets executed before every experiment run."""
-        pass
-
-    async def finish(self):
-        """Gets executed after every experiment run."""
-        pass
+        await super().__ainit__(walker=walker, separate_scans=separate_scans,name_fmt=name_fmt)
+        await self.set_log_file_prefix("experiment")
 
     async def attach(self, addon):
         """Attach *addon* to all acquisitions."""
@@ -465,58 +351,7 @@ class Experiment(RunnableParameterizable):
 
     @background
     async def _run(self):
-        self.ready_to_prepare_next_sample.clear()
-        start_time = time.time()
-        handler = None
-        iteration = await self.get_iteration()
-        separate_scans = await self.get_separate_scans()
-
-        if self.walker:
-            if separate_scans:
-                await self.walker.descend((await self.get_name_fmt()).format(iteration))
-            if os.path.exists(await self.walker.get_current()):
-                handler: AsyncLoggingHandlerCloser = await self.walker.register_logger(
-                    logger_name=self.__class__.__name__,
-                    log_level=logging.NOTSET,
-                    file_name="experiment.log"
-                )
-                self.log.addHandler(handler)
-                if await self.get_log_devices_at_start():
-                    exp_metadata: str = await self._prepare_metadata_str()
-                    await self.walker.log_to_json(payload=exp_metadata,
-                                                  filename="experiment_start.json")
-            self._current_name = get_basename(await self.walker.get_current())
-        self.log.info(await self.info_table)
-        for name, device in self._devices_to_log.items():
-            self.log.info(f"Device {name}:")
-            self.log.info(await device.info_table)
-        LOG.debug('Experiment iteration %d start', iteration)
-
-        try:
-            await self.prepare()
-            await self.acquire()
-        finally:
-            try:
-                await self.finish()
-                if self.walker:
-                    if await self.get_log_devices_at_finish():
-                        exp_metadata: str = await self._prepare_metadata_str()
-                        await self.walker.log_to_json(payload=exp_metadata,
-                                                      filename="experiment_finish.json")
-            except Exception as e:
-                LOG.warning(f"Error `{e}' while finalizing experiment")
-                raise StateError('error', msg=str(e))
-            finally:
-                self.ready_to_prepare_next_sample.set()
-                if separate_scans and self.walker:
-                    await self.walker.ascend()
-                LOG.debug('Experiment iteration %d duration: %.2f s',
-                          iteration, time.time() - start_time)
-                if handler:
-                    await handler.aclose()
-                    self.log.removeHandler(handler)
-                await self.set_iteration(iteration + 1)
-
+        await self.acquire()
 
 class AcquisitionError(Exception):
     """Acquisition-related exceptions."""

--- a/concert/experiments/base.py
+++ b/concert/experiments/base.py
@@ -7,23 +7,14 @@ import asyncio
 import functools
 import inspect
 import logging
-import os
 import time
-import json
 
-import concert.devices.base
 from concert.coroutines.base import background, broadcast, start
 from concert.coroutines.sinks import count
 from concert.progressbar import wrap_iterable
 from concert.base import (
-    check,
-    Parameter,
-    Selection,
-    StateError,
-    RunnableParameterizable, TargetAccessError
+    RunnableParameterizable,
 )
-from concert.helpers import get_basename
-from concert.loghandler import AsyncLoggingHandlerCloser
 from functools import partial
 
 
@@ -219,12 +210,6 @@ class Acquisition(RunnableParameterizable):
                     await self.producer.unregister_endpoint(consumer.addon.endpoint)
                     await consumer.addon.disconnect_endpoint()
 
-    @background
-    @check(source=['standby', 'error', 'cancelled'], target=['standby', 'cancelled'])
-    async def __call__(self):
-        self._run_awaitable = self._run()
-        await self._run_awaitable
-
     def __repr__(self):
         return "Acquisition({})".format(self.name)
 
@@ -264,154 +249,15 @@ class Experiment(RunnableParameterizable):
 
     """
 
-    iteration = Parameter()
-    separate_scans = Parameter()
-    name_fmt = Parameter()
-    current_name = Parameter(help="Name of the current iteration")
-    log_level = Selection(['critical', 'error', 'warning', 'info', 'debug'])
-    log_devices_at_start = Parameter()
-    log_devices_at_finish = Parameter()
+
 
     async def __ainit__(self, *, acquisitions, walker=None, separate_scans=True, name_fmt='scan_{:>04}', **kwargs):
+
         self._acquisitions = []
         for acquisition in acquisitions:
             self.add(acquisition)
-        self.walker = walker
-        self._separate_scans = separate_scans
-        self._name_fmt = name_fmt
-        self._current_name = ""
-        self._iteration = 0
-        self.log = LOG
-        self._devices_to_log = {}
-        self._devices_to_log_optional = {}
-        self._log_devices_at_start = None
-        self._log_devices_at_finish = None
-        self.ready_to_prepare_next_sample = asyncio.Event()
-        await super().__ainit__(**kwargs)
-        await self.set_log_devices_at_start(True)
-        await self.set_log_devices_at_finish(True)
-
-        if separate_scans and walker:
-            # The data is not supposed to be overwritten, so find an iteration which
-            # hasn't been used yet
-            while await self.walker.exists(self._name_fmt.format(self._iteration)):
-                self._iteration += 1
-
-    async def _set_log_devices_at_start(self, log):
-        self._log_devices_at_start = bool(log)
-
-    async def _get_log_devices_at_start(self):
-        return self._log_devices_at_start
-
-    async def _set_log_devices_at_finish(self, log):
-        self._log_devices_at_finish = bool(log)
-
-    async def _get_log_devices_at_finish(self):
-        return self._log_devices_at_finish
-
-    def add_device_to_log(self, name: str, device: concert.devices.base.Device, optional=False):
-        """
-        Add a device to log.
-
-        :param name: Name of the device
-        :param device: Device to log
-        :param optional: If True, an exception when trying to log the device will not cause an
-            error.
-        """
-        if optional:
-            self._devices_to_log_optional[name] = device
-        else:
-            self._devices_to_log[name] = device
-
-    async def _prepare_metadata_str(self) -> str:
-        """Prepares the experiment metadata to be written to file. It is
-        a dictionary which potentially encapsulates one or more dictionary
-        objects.
-        """
-        metadata = {}
-        exp_params = {}
-        for param in self:
-            exp_params[param.name] = str(await param.get())
-        metadata["experiment"] = exp_params
-        for name, device in self._devices_to_log.items():
-            device_data = {}
-            for param in device:
-                device_data[param.name] = {}
-                device_data[param.name]["value"] = str(await param.get())
-                try:
-                    device_data[param.name]["target"] = str(await param.get_target())
-                except TargetAccessError:
-                    pass
-                try:
-                    device_data[param.name]["lower_limit"] = str(await param.get_lower())
-                    device_data[param.name]["upper_limit"] = str(await param.get_upper())
-                    device_data[param.name]["lower_user_limit"] = str(await param.get_lower_user())
-                    device_data[param.name]["upper_user_limit"] = str(await param.get_upper_user())
-                    device_data[param.name]["lower_external_limit"] = str(await param.get_lower_external())
-                    device_data[param.name]["upper_external_limit"] = str(await param.get_upper_external())
-                except AttributeError:
-                    pass
-            metadata[name] = device_data
-
-        for name, device in self._devices_to_log_optional.items():
-            device_data = {}
-            for param in device:
-                try:
-                    device_data[param.name] = {}
-                    device_data[param.name]["value"] = str(await param.get())
-                    try:
-                        device_data[param.name]["target"] = str(await param.get_target())
-                    except TargetAccessError:
-                        pass
-                    try:
-                        device_data[param.name]["lower_limit"] = str(await param.get_lower())
-                        device_data[param.name]["upper_limit"] = str(await param.get_upper())
-                        device_data[param.name]["lower_user_limit"] = str(await param.get_lower_user())
-                        device_data[param.name]["upper_user_limit"] = str(await param.get_upper_user())
-                        device_data[param.name]["lower_external_limit"] = str(await param.get_lower_external())
-                        device_data[param.name]["upper_external_limit"] = str(await param.get_upper_external())
-                    except AttributeError:
-                        pass
-                except Exception as e:
-                    self.log.info(f"Error while logging optional device {name}")
-                    self.log.info(e)
-            metadata[name] = device_data
-        return json.dumps(metadata, indent=4)
-
-    async def _get_iteration(self):
-        return self._iteration
-
-    async def _set_iteration(self, iteration):
-        self._iteration = iteration
-
-    async def _get_current_name(self):
-        return self._current_name
-
-    async def _get_separate_scans(self):
-        return self._separate_scans
-
-    async def _set_separate_scans(self, separate_scans):
-        self._separate_scans = separate_scans
-
-    async def _get_name_fmt(self):
-        return self._name_fmt
-
-    async def _set_name_fmt(self, fmt):
-        self._name_fmt = fmt
-
-    async def _get_log_level(self):
-        return logging.getLevelName(self.log.getEffectiveLevel()).lower()
-
-    async def _set_log_level(self, level):
-        self.log.setLevel(level.upper())
-
-    async def prepare(self):
-        """Gets executed before every experiment run."""
-        pass
-
-    async def finish(self):
-        """Gets executed after every experiment run."""
-        pass
+        await super().__ainit__(walker=walker, separate_scans=separate_scans,name_fmt=name_fmt, **kwargs)
+        await self.set_log_file_prefix("experiment")
 
     async def attach(self, addon):
         """Attach *addon* to all acquisitions."""
@@ -488,62 +334,11 @@ class Experiment(RunnableParameterizable):
         for acq in wrap_iterable(self._acquisitions):
             if await self.get_state() != 'running':
                 break
-            await acq()
+            await acq.run()
 
     @background
     async def _run(self):
-        self.ready_to_prepare_next_sample.clear()
-        start_time = time.time()
-        handler = None
-        iteration = await self.get_iteration()
-        separate_scans = await self.get_separate_scans()
-
-        if self.walker:
-            if separate_scans:
-                await self.walker.descend((await self.get_name_fmt()).format(iteration))
-            if os.path.exists(await self.walker.get_current()):
-                handler: AsyncLoggingHandlerCloser = await self.walker.register_logger(
-                    logger_name=self.__class__.__name__,
-                    log_level=logging.NOTSET,
-                    file_name="experiment.log"
-                )
-                self.log.addHandler(handler)
-                if await self.get_log_devices_at_start():
-                    exp_metadata: str = await self._prepare_metadata_str()
-                    await self.walker.log_to_json(payload=exp_metadata,
-                                                  filename="experiment_start.json")
-            self._current_name = get_basename(await self.walker.get_current())
-        self.log.info(await self.info_table)
-        for name, device in self._devices_to_log.items():
-            self.log.info(f"Device {name}:")
-            self.log.info(await device.info_table)
-        LOG.debug('Experiment iteration %d start', iteration)
-
-        try:
-            await self.prepare()
-            await self.acquire()
-        finally:
-            try:
-                await self.finish()
-                if self.walker:
-                    if await self.get_log_devices_at_finish():
-                        exp_metadata: str = await self._prepare_metadata_str()
-                        await self.walker.log_to_json(payload=exp_metadata,
-                                                      filename="experiment_finish.json")
-            except Exception as e:
-                LOG.warning(f"Error `{e}' while finalizing experiment")
-                raise StateError('error', msg=str(e))
-            finally:
-                self.ready_to_prepare_next_sample.set()
-                if separate_scans and self.walker:
-                    await self.walker.ascend()
-                LOG.debug('Experiment iteration %d duration: %.2f s',
-                          iteration, time.time() - start_time)
-                if handler:
-                    await handler.aclose()
-                    self.log.removeHandler(handler)
-                await self.set_iteration(iteration + 1)
-
+        await self.acquire()
 
 class AcquisitionError(Exception):
     """Acquisition-related exceptions."""

--- a/concert/experiments/imaging.py
+++ b/concert/experiments/imaging.py
@@ -559,10 +559,9 @@ class RadiographyLogic(Experiment):
         await self.stop_sample_exposure()
         self._finished = True
 
-    @background
-    async def run(self):
+    async def early_prepare(self):
         self._finished = False
-        await super().run()
+        await super().early_prepare()
 
     @abstractmethod
     async def _take_darks(self):

--- a/concert/tests/integration/test_director.py
+++ b/concert/tests/integration/test_director.py
@@ -7,6 +7,8 @@ import unittest
 import numpy as np
 from typing import Tuple
 from time import time
+from unittest.mock import AsyncMock, patch
+from concert.base import StateError
 from concert.storage import DirectoryWalker
 from concert.experiments.base import Experiment as BaseExperiment, Acquisition, local
 from concert.experiments.base import Consumer as AcquisitionConsumer
@@ -47,6 +49,43 @@ class BrokenExperiment(Experiment):
     async def _frame_producer(self):
         yield None
         raise Exception("Experiment broken")
+
+
+class FailingExperiment(Experiment):
+    """Experiment used to exercise cleanup through a complete director stack."""
+
+    async def __ainit__(self, *, walker, separate_scans, failure_stage, **kwargs):
+        self.failure_stage = failure_stage
+        self.events = []
+        acquisition = await Acquisition(name="test", producer_corofunc=self._frame_producer)
+        await super().__ainit__(acquisitions=[acquisition], walker=walker,
+                                separate_scans=separate_scans, **kwargs)
+
+    @local
+    async def _frame_producer(self):
+        yield np.ones((1, 1))
+        if self.failure_stage == "acquisition":
+            raise RuntimeError("Acquisition failed")
+
+    async def early_prepare(self):
+        self.events.append("early_prepare")
+        if self.failure_stage == "early_prepare":
+            raise RuntimeError("Early preparation failed")
+
+    async def prepare(self):
+        self.events.append("prepare")
+        if self.failure_stage == "prepare":
+            raise RuntimeError("Preparation failed")
+
+    async def finish(self):
+        self.events.append("finish")
+        if self.failure_stage == "finish":
+            raise RuntimeError("Finish failed")
+
+    async def late_finish(self):
+        self.events.append("late_finish")
+        if self.failure_stage == "late_finish":
+            raise RuntimeError("Late finish failed")
 
 
 class EarlyReadyExperiment(Experiment):
@@ -132,6 +171,74 @@ class DirectorTestBrokenExperiment(TestCase):
         except Exception as e:
             LOG.info(e)
         self.assertEqual(await self.director.get_state(), "error")
+
+    async def test_walker_is_reset_after_acquisition_failure(self):
+        with self.assertRaises(StateError):
+            await self.director.run()
+
+        self.assertEqual(await self.walker.get_current(), await self.walker.get_root())
+        self.assertEqual(await self.experiment.get_state(), "error")
+
+
+class DirectorCleanupTest(TestCase):
+    async def _run_failing_stack(self, failure_stage):
+        experiment = await FailingExperiment(
+            walker=self.walker,
+            separate_scans=False,
+            failure_stage=failure_stage,
+        )
+        director = await Director(experiment=experiment, num_iterations=1)
+
+        with self.assertRaises(StateError):
+            await director.run()
+
+        self.assertEqual(await self.walker.get_current(), await self.walker.get_root())
+        self.assertEqual(await director.get_state(), "error")
+        self.assertFalse(await experiment.get_separate_scans())
+        return experiment
+
+    async def test_walker_is_reset_after_early_prepare_failure(self):
+        experiment = await self._run_failing_stack("early_prepare")
+        self.assertEqual(["early_prepare"], experiment.events)
+
+    async def test_walker_is_reset_after_prepare_failure(self):
+        experiment = await self._run_failing_stack("prepare")
+        self.assertEqual(["early_prepare", "prepare", "finish", "late_finish"],
+                         experiment.events)
+
+    async def test_walker_is_reset_after_acquisition_failure(self):
+        experiment = await self._run_failing_stack("acquisition")
+        self.assertEqual(["early_prepare", "prepare", "finish", "late_finish"],
+                         experiment.events)
+
+    async def test_walker_is_reset_after_finish_failure(self):
+        experiment = await self._run_failing_stack("finish")
+        self.assertEqual(["early_prepare", "prepare", "finish"], experiment.events)
+
+    async def test_walker_is_reset_after_late_finish_failure(self):
+        experiment = await self._run_failing_stack("late_finish")
+        self.assertEqual(["early_prepare", "prepare", "finish", "late_finish"],
+                         experiment.events)
+
+    async def test_walker_is_reset_after_logging_failure(self):
+        experiment = await FailingExperiment(
+            walker=self.walker,
+            separate_scans=False,
+            failure_stage="none",
+        )
+        director = await Director(experiment=experiment, num_iterations=1)
+        handlers_before = list(experiment.log.handlers)
+
+        with patch.object(
+            experiment,
+            "_prepare_metadata_str",
+            new=AsyncMock(side_effect=RuntimeError("Metadata logging failed")),
+        ), self.assertRaises(StateError):
+            await director.run()
+
+        self.assertEqual(await self.walker.get_current(), await self.walker.get_root())
+        self.assertEqual(await director.get_state(), "error")
+        self.assertEqual(handlers_before, experiment.log.handlers)
 
 
 @slow

--- a/concert/tests/integration/test_director.py
+++ b/concert/tests/integration/test_director.py
@@ -112,6 +112,11 @@ class DirectorTest(TestCase):
         self.assertEqual(await self.director.get_state(), "standby")
         self.assertEqual(await self.experiment.get_iteration(), 5)
 
+    async def test_constructor_arguments_are_forwarded(self):
+        director = await Director(experiment=self.experiment, num_iterations=0,
+                                  name_fmt="director_{:03d}")
+        self.assertEqual("director_{:03d}", await director.get_name_fmt())
+
 
 @slow
 class DirectorTestBrokenExperiment(TestCase):
@@ -216,7 +221,7 @@ class TestableLoggingDirector(BaseDirector):
         return await self._get_iteration_name(iteration)
 
     async def get_iteration(self) -> int:
-        return self._get_current_iteration()
+        return await self._get_current_iteration()
 
 
 class TestDirectorLogging(unittest.IsolatedAsyncioTestCase):

--- a/concert/tests/integration/test_experiments.py
+++ b/concert/tests/integration/test_experiments.py
@@ -35,6 +35,7 @@ from concert.devices.cameras.dummy import Camera
 from concert.devices.shutters.dummy import Shutter
 from concert.devices.motors.dummy import LinearMotor
 from concert.helpers import CommData
+from concert.loghandler import RemoteLoggingHandler
 from concert.tests import TestCase, suppressed_logging, assert_almost_equal
 from concert.storage import DirectoryWalker, DummyWalker, RemoteDirectoryWalker
 from concert.tests.util.mocks import MockWalkerDevice
@@ -142,9 +143,16 @@ class TestAcquisition(TestCase):
         self.acquisition.add_consumer(AcquisitionConsumer(self.consume))
 
     async def test_run(self):
-        await self.acquisition()
+        await self.acquisition.run()
         self.assertTrue(self.acquired)
         self.assertEqual(1, self.item)
+        self.assertEqual('standby', await self.acquisition.get_state())
+
+    async def test_run_is_the_only_execution_entrypoint(self):
+        self.assertFalse(hasattr(self.acquisition, '__call__'))
+
+        with self.assertRaises(TypeError):
+            self.acquisition()
 
     async def acquire(self):
         self.acquired = True
@@ -458,8 +466,8 @@ class TestExperimentLogging(unittest.IsolatedAsyncioTestCase):
             self._item = item
 
     async def test_experiment_logging(self) -> None:
-        self._experiment.set_log_devices_at_start(True)
-        self._experiment.set_log_devices_at_start(True)
+        await self._experiment.set_log_devices_at_start(True)
+        await self._experiment.set_log_devices_at_start(True)
         _ = await self._experiment.run()
         self.assertEqual(self._visited, len(self._experiment.acquisitions))
         self.assertEqual(self._acquired, len(self._experiment.acquisitions))
@@ -473,26 +481,26 @@ class TestExperimentLogging(unittest.IsolatedAsyncioTestCase):
         mock_device = self._walker.device.mock_device
 
         mock_device.reset_mock()
-        self._experiment.set_log_devices_at_start(True)
-        self._experiment.set_log_devices_at_finish(True)
+        await self._experiment.set_log_devices_at_start(True)
+        await self._experiment.set_log_devices_at_finish(True)
         _ = await self._experiment.run()
         self.assertEqual(mock_device.log_to_json.call_count, 2)
 
         mock_device.reset_mock()
-        self._experiment.set_log_devices_at_start(False)
-        self._experiment.set_log_devices_at_finish(True)
+        await self._experiment.set_log_devices_at_start(False)
+        await self._experiment.set_log_devices_at_finish(True)
         _ = await self._experiment.run()
         self.assertEqual(mock_device.log_to_json.call_count, 1)
 
         mock_device.reset_mock()
-        self._experiment.set_log_devices_at_start(True)
-        self._experiment.set_log_devices_at_finish(False)
+        await self._experiment.set_log_devices_at_start(True)
+        await self._experiment.set_log_devices_at_finish(False)
         _ = await self._experiment.run()
         self.assertEqual(mock_device.log_to_json.call_count, 1)
 
         mock_device.reset_mock()
-        self._experiment.set_log_devices_at_start(False)
-        self._experiment.set_log_devices_at_finish(False)
+        await self._experiment.set_log_devices_at_start(False)
+        await self._experiment.set_log_devices_at_finish(False)
         _ = await self._experiment.run()
         self.assertEqual(mock_device.log_to_json.call_count, 0)
 
@@ -504,6 +512,8 @@ class TestExperimentLogging(unittest.IsolatedAsyncioTestCase):
         # Test that the experiment fails when a non-optional device is broken
         with self.assertRaises(BrokenDeviceException):
             await self._experiment.run()
+        self.assertFalse(any(isinstance(handler, RemoteLoggingHandler)
+                             for handler in self._experiment.log.handlers))
 
         self._experiment._devices_to_log = {}
         self._experiment._devices_to_log_optional = {}

--- a/docs/devel/tutorial.rst
+++ b/docs/devel/tutorial.rst
@@ -470,7 +470,7 @@ An example of an acquisition could look like this::
     # *producer* is not specified, *Consumer* class handles this
     acquisition.add_consumer(Consumer(consume, corofunc_args=("foo",)))
     # Now we can run the acquisition
-    await acquisition()
+    await acquisition.run()
 
 
 `Local` consumers must always take at least one argument, which is the producer

--- a/docs/user/topics/experiments.rst
+++ b/docs/user/topics/experiments.rst
@@ -329,8 +329,8 @@ Advanced
 Sometimes we need finer control over when exactly is the data acquired and worry
 about the download later. We can use the *acquire* argument to acquisition
 class. This means that the data acquisition can be invoked before data download.
-Acquisition calls its *acquire* first and only when it is finished connects
-producer with consumers.
+Acquisition runs its *acquire* hook first and only when it is finished connects
+the producer with consumers.
 
 The Experiment class has the attribute
 :py:attr:`.base.Experiment.ready_to_prepare_next_sample` which is an instance of


### PR DESCRIPTION
Here I want to generalize the DirectorExperiment/Acquisitions/RunnableParameterizable a bit.

Logging in now handles the same way in all RunnableParameterizable. This also allows to seamlessly nest Directors.

Acquisitions, Experiments and Directors now have the same interface.

- Nesting of directors is transparently possible
- Walker ascend/descend is done the same way in all objects
- Acquistions.__call__ is replaced by Acquisition.run() for consistency
- Logging works the same way for Acquisition/Experiment/Director